### PR TITLE
Auto/controlled upload of instructions, agent source code to server

### DIFF
--- a/XiansAi.Lib.Src/Flow/Agent.cs
+++ b/XiansAi.Lib.Src/Flow/Agent.cs
@@ -10,12 +10,14 @@ public class Agent
 {
     private readonly List<IFlow> _flows = new();
     private readonly List<IBot> _bots = new();
-    
+    private readonly bool _uploadResources;
     public string Name { get; }
 
-    public Agent(string name)
+    public Agent(string name, bool uploadResources)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
+        _uploadResources = uploadResources
+            || (bool.TryParse(Environment.GetEnvironmentVariable("UPLOAD_RESOURCES"), out var flag) && flag);
         AgentContext.AgentName = name;
     }
 
@@ -49,7 +51,7 @@ public class Agent
     public async Task RunAsync(RunnerOptions? options = null)
     {
         var tasks = new List<Task>();        
-        await new ResourceUploader().UploadResource();
+        await new ResourceUploader(_uploadResources).UploadResource();
 
         // Run all flows
         foreach (var flow in _flows)

--- a/XiansAi.Lib.Src/Flow/Agent.cs
+++ b/XiansAi.Lib.Src/Flow/Agent.cs
@@ -13,11 +13,12 @@ public class Agent
     private readonly bool _uploadResources;
     public string Name { get; }
 
-    public Agent(string name, bool uploadResources)
+    public Agent(string name, bool? uploadResources=null)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
-        _uploadResources = uploadResources
+        _uploadResources = uploadResources.GetValueOrDefault()
             || (bool.TryParse(Environment.GetEnvironmentVariable("UPLOAD_RESOURCES"), out var flag) && flag);
+
         AgentContext.AgentName = name;
     }
 

--- a/XiansAi.Lib.Src/Flow/Agent.cs
+++ b/XiansAi.Lib.Src/Flow/Agent.cs
@@ -1,3 +1,4 @@
+using Server;
 using XiansAi.Models;
 
 namespace XiansAi.Flow;
@@ -47,7 +48,8 @@ public class Agent
     /// </summary>
     public async Task RunAsync(RunnerOptions? options = null)
     {
-        var tasks = new List<Task>();
+        var tasks = new List<Task>();        
+        await new ResourceUploader().UploadResource();
 
         // Run all flows
         foreach (var flow in _flows)

--- a/XiansAi.Lib.Src/Models/ActivityDefinition.cs
+++ b/XiansAi.Lib.Src/Models/ActivityDefinition.cs
@@ -1,9 +1,14 @@
 namespace XiansAi.Models;
+using System.Text.Json.Serialization;
 
 public class ActivityDefinition
 {
-    public required List<string> AgentToolNames { get; set; } = [];
-    public required List<string> KnowledgeIds { get; set; } = [];
+    [JsonPropertyName("activityName")]
     public required string ActivityName { get; set; }
+    [JsonPropertyName("agentToolNames")]
+    public required List<string> AgentToolNames { get; set; } = [];
+    [JsonPropertyName("knowledgeIds")]
+    public required List<string> KnowledgeIds { get; set; } = [];
+    [JsonPropertyName("parameterDefinitions")]
     public required List<ParameterDefinition> ParameterDefinitions { get; set; } = [];
 }

--- a/XiansAi.Lib.Src/Models/FlowDefinition.cs
+++ b/XiansAi.Lib.Src/Models/FlowDefinition.cs
@@ -1,15 +1,22 @@
 
 using System.Reflection;
+using System.Text.Json.Serialization;
 
 namespace XiansAi.Models;
 
 public class FlowDefinition
 {
+    [JsonPropertyName("agent")]
     public required string Agent { get; set; }
+    [JsonPropertyName("workflowType")]
     public required string WorkflowType { get; set; }
-    public required ActivityDefinition[] ActivityDefinitions { get; set; } = [];
-    public required List<ParameterDefinition> ParameterDefinitions { get; set; } = [];
+    
+    [JsonPropertyName("source")]
     public string? Source { get; set; } = string.Empty;
+    [JsonPropertyName("activityDefinitions")]
+    public required ActivityDefinition[] ActivityDefinitions { get; set; } = [];
+    [JsonPropertyName("parameterDefinitions")]
+    public required List<ParameterDefinition> ParameterDefinitions { get; set; } = [];
 }
 
 public class ParameterDefinition

--- a/XiansAi.Lib.Src/Server/ResourceUploader.cs
+++ b/XiansAi.Lib.Src/Server/ResourceUploader.cs
@@ -23,9 +23,9 @@ public class ResourceUploader : IResourceUploader
 
     private static readonly string[] SupportedExtensions = [".md", ".txt", ".json"];
 
-    public ResourceUploader()
+    public ResourceUploader(bool uploadResource)
     {
-        _uploadResource = bool.TryParse(Environment.GetEnvironmentVariable("UPLOAD_RESOURCES"), out var flag) && flag;
+        _uploadResource = uploadResource;
         _localFolder = Environment.GetEnvironmentVariable("LOCAL_KNOWLEDGE_FOLDER");
     }
 

--- a/XiansAi.Lib.Src/Server/ResourceUploader.cs
+++ b/XiansAi.Lib.Src/Server/ResourceUploader.cs
@@ -1,0 +1,105 @@
+using XiansAi.Knowledge;
+using XiansAi.Logging;
+
+namespace Server;
+
+/// <summary>
+/// Defines a service for uploading flow definitions to the server.
+/// </summary>
+public interface IResourceUploader
+{
+    /// <summary>
+    /// Uploads all supported resources from the local folder to the server.
+    /// </summary>
+    /// <returns>True if upload was attempted and succeeded, false otherwise.</returns>
+    Task<bool> UploadResource();
+}
+
+public class ResourceUploader : IResourceUploader
+{
+    private readonly Logger<ResourceUploader> _logger = Logger<ResourceUploader>.For();
+    private readonly bool _uploadResource;
+    private readonly string? _localFolder;
+
+    private static readonly string[] SupportedExtensions = [".md", ".txt", ".json"];
+
+    public ResourceUploader()
+    {
+        _uploadResource = bool.TryParse(Environment.GetEnvironmentVariable("UPLOAD_RESOURCES"), out var flag) && flag;
+        _localFolder = Environment.GetEnvironmentVariable("LOCAL_KNOWLEDGE_FOLDER");
+    }
+
+    /// <summary>
+    /// Uploads a resource to the server.
+    /// </summary>
+    /// <param name="resourceName">The name of the resource to upload</param>
+    /// <param name="resourceType">The type of the resource to upload</param>
+    /// <param name="resourceContent">The content of the resource to upload</param>
+    /// <returns>A task representing the upload operation</returns>
+    public async Task<bool> UploadResource()
+    {
+        if (!_uploadResource)
+        {
+            _logger.LogInformation("UPLOAD_RESOURCES is not set. Skipping resource upload.");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(_localFolder) || !Directory.Exists(_localFolder))
+        {
+            _logger.LogWarning($"Knowledge folder not found or invalid: {_localFolder}");
+            return false;
+        }
+
+        var files = SupportedExtensions
+            .SelectMany(ext => Directory.GetFiles(_localFolder, $"*{ext}"))
+            .ToArray();
+
+        if (files.Length == 0)
+        {
+            _logger.LogInformation($"No supported files (.md, .txt, .json) found in {_localFolder}");
+            return true; // Operation was valid, just no files to process
+        }
+
+        foreach (var filePath in files)
+        {
+            var resourceName = Path.GetFileNameWithoutExtension(filePath);
+            var resourceType = GetResourceTypeFromExtension(Path.GetExtension(filePath));
+            string resourceContent;
+
+            try
+            {
+                resourceContent = await File.ReadAllTextAsync(filePath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to read file '{filePath}': {ex.Message}");
+                continue;
+            }
+
+            _logger.LogInformation($"Uploading knowledge: {resourceName} ({resourceType})");
+
+            try
+            {
+                bool result = await KnowledgeHub.Update(resourceName, resourceType, resourceContent);
+                _logger.LogInformation($"Upload result for '{resourceName}': {result}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error updating knowledge '{resourceName}': {ex.Message}");
+            }
+        }
+
+        return true;
+    }
+
+    private static string GetResourceTypeFromExtension(string extension)
+    {
+        return extension.ToLower() switch
+        {
+            ".md" => "markdown",
+            ".txt" => "text",
+            ".json" => "json",
+            _ => "unknown"
+        };
+    }
+}

--- a/XiansAi.Lib.Src/Server/SystemActivities.cs
+++ b/XiansAi.Lib.Src/Server/SystemActivities.cs
@@ -85,12 +85,6 @@ public class SystemActivities
 
     public static async Task<bool> UpdateKnowledgeAsyncStatic(string knowledgeName, string knowledgeType, string knowledgeContent)
     {
-        return await UpdateKnowledgeAsyncStatic(knowledgeName, knowledgeType, knowledgeContent);
-    }
-
-    [Activity]
-    public async Task<bool> UpdateKnowledgeAsync(string knowledgeName, string knowledgeType, string knowledgeContent)
-    {
         try
         {
             var knowledgeUpdater = new KnowledgeUpdaterImpl();
@@ -102,6 +96,12 @@ public class SystemActivities
             _logger.LogError(ex, "Error updating knowledge: {InstructionName}", knowledgeName);
             throw;
         }
+    }
+
+    [Activity]
+    public async Task<bool> UpdateKnowledgeAsync(string knowledgeName, string knowledgeType, string knowledgeContent)
+    {
+        return await UpdateKnowledgeAsyncStatic(knowledgeName, knowledgeType, knowledgeContent);
 
     }
 


### PR DESCRIPTION
### **✅ Controlled Upload of Knowledge Files**
Users can now manage the upload of local knowledge files to the server through either environment variables or a CLI flag:

- To specify the folder containing knowledge files, use the .env variable:

> `LOCAL_KNOWLEDGE_FOLDER=<path-to-knowledge-folder>`

- To control whether the knowledge files should be uploaded:

1. Via CLI: Use the flag` --upload-resources` when running the agent. This takes precedence over the environment variable.
2. Via .env: Set the following variable:

> `UPLOAD_RESOURCES=true`

  Upload behavior:
  - If `--upload-resources` is passed via CLI → upload will occur.
  - If CLI flag is not present, it falls back to the `.env` setting:
    - `UPLOAD_RESOURCES=true` → upload will occur.
    - `UPLOAD_RESOURCES=false` or missing → upload will not occur.

###  **✅ Controlled Upload of Source Code**

The agent now uses a hash-based mechanism in the client side to determine whether the current source code needs to be uploaded to there server:

- A hash of the source code is generated locally and compared with the value stored in the database.
- If the hashes match, the source code has not changed, and upload is skipped.
- If the hashes do not match, the source code has changed and will be uploaded to the server, updating the value in the database accordingly.

### **✅ Prerequisites to Use the `--upload-resources` CLI Flag**

To enable support for the `--upload-resources` command-line option, ensure the following is defined in your `Program.cs` file:

>  `bool uploadResources = args.Contains("--upload-resources");`
> `Agent agentInfo = new Agent(<AgentName>, uploadResources);`


This logic checks for the presence of the `--upload-resources` flag when running the agent and passes the corresponding boolean value to the `Agent `class to control whether local knowledge files should be uploaded.

