### PR TITLE
Add configurable HttpClient with timeout for OpenAI and Azure OpenAI Chat completion

### DIFF
--- a/XiansAi.Lib.Src/Flow/SemanticRouter/SemanticRouter.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/SemanticRouter.cs
@@ -270,13 +270,19 @@ internal class SemanticRouterHubImpl
         var providerName = GetProviderName();
         var builder = Kernel.CreateBuilder();
 
+        var httpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromMinutes(5)
+        };
+
         switch (providerName?.ToLower())
         {
             case "openai":
                 _logger.LogDebug("Adding OpenAI chat completion with model {ModelName}", GetModelName());
-                builder.Services.AddOpenAIChatCompletion(
+                builder.AddOpenAIChatCompletion(
                     modelId: GetModelName(),
-                    apiKey: GetApiKey()
+                    apiKey: GetApiKey(),
+                    httpClient: httpClient
                 );
                 break;
 
@@ -285,7 +291,8 @@ internal class SemanticRouterHubImpl
                 builder.AddAzureOpenAIChatCompletion(
                     deploymentName: GetDeploymentName(),
                     endpoint: GetEndpoint(),
-                    apiKey: GetApiKey()
+                    apiKey: GetApiKey(),
+                    httpClient: httpClient
                 );
                 break;
 


### PR DESCRIPTION
At the moment long chat completions using semantic router hub for deterministic flows, large data which take more than 100 seconds timeouts. so increased the timeout time to 5 mins.  and due to implemented retry policies it will eventually execute but to avoid timeout issues 

When using:
SemanticRouterHub.ChatCompletionAsync


Error:
```  ---> System.Threading.Tasks.TaskCanceledException: The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.
       ---> System.TimeoutException: The operation was canceled.
       ---> System.Threading.Tasks.TaskCanceledException: The operation was canceled.
       ---> System.IO.IOException: Unable to read data from the transport connection: Operation canceled.
       ---> System.Net.Sockets.SocketException (125): Operation canceled
         --- End of inner exception stack trace ---
         at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
         at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
         at System.Net.Security.SslStream.EnsureFullTlsFrameAsync[TIOAdapter](CancellationToken cancellationToken, Int32 estimatedSize)
         at System.Runtime.CompilerServices.PoolingAsyncValueTaskMethodBuilder`1.StateMachineBox`1.System.Threading.Tasks.Sources.IValueTaskSource<TResult>.GetResult(Int16 token)
         at System.Net.Security.SslStream.ReadAsyncInternal[TIOAdapter](Memory`1 buffer, CancellationToken cancellationToken)
         at System.Runtime.CompilerServices.PoolingAsyncValueTaskMethodBuilder`1.StateMachineBox`1.System.Threading.Tasks.Sources.IValueTaskSource<TResult>.GetResult(Int16 token)
         at System.Net.Http.HttpConnection.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
         --- End of inner exception stack trace ---
         at System.Net.Http.HttpConnection.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
         at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
         at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
         at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
         --- End of inner exception stack trace ---
         --- End of inner exception stack trace ---
         at System.Net.Http.HttpClient.HandleFailure(Exception e, Boolean telemetryStarted, HttpResponseMessage response, CancellationTokenSource cts, CancellationToken cancellationToken, CancellationTokenSource pendingRequestsCts)
         at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
         at System.ClientModel.Primitives.HttpClientPipelineTransport.ProcessSyncOrAsync(PipelineMessage message, Boolean async)
         at System.ClientModel.Primitives.HttpClientPipelineTransport.ProcessCoreAsync(PipelineMessage message)
         at System.ClientModel.Primitives.PipelineTransport.ProcessSyncOrAsync(PipelineMessage message, Boolean async)
         at System.ClientModel.Primitives.PipelineTransport.ProcessAsync(PipelineMessage message)
         at System.ClientModel.Primitives.PipelineTransport.ProcessAsync(PipelineMessage message, IReadOnlyList`1 pipeline, Int32 currentIndex)
         at System.ClientModel.Primitives.PipelinePolicy.ProcessNextAsync(PipelineMessage message, IReadOnlyList`1 pipeline, Int32 currentIndex)
         at System.ClientModel.Primitives.MessageLoggingPolicy.ProcessSyncOrAsync(PipelineMessage message, IReadOnlyList`1 pipeline, Int32 currentIndex, Boolean async)
         at System.ClientModel.Primitives.MessageLoggingPolicy.ProcessAsync(PipelineMessage message, IReadOnlyList`1 pipeline, Int32 currentIndex)
         at System.ClientModel.Primitives.PipelinePolicy.ProcessNextAsync(PipelineMessage message, IReadOnlyList`1 pipeline, Int32 currentIndex)
         at System.ClientModel.Primitives.ApiKeyAuthenticationPolicy.ProcessAsync(PipelineMessage message, IReadOnlyList`1 pipeline, Int32 currentIndex)
         at System.ClientModel.Primitives.PipelinePolicy.ProcessNextAsync(PipelineMessage message, IReadOnlyList`1 pipeline, Int32 currentIndex)
         at System.ClientModel.Primitives.ClientRetryPolicy.ProcessSyncOrAsync(PipelineMessage message, IReadOnlyList`1 pipeline, Int32 currentIndex, Boolean async)
         at System.ClientModel.Primitives.ClientRetryPolicy.ProcessSyncOrAsync(PipelineMessage message, IReadOnlyList`1 pipeline, Int32 currentIndex, Boolean async)
         at System.ClientModel.Primitives.ClientRetryPolicy.ProcessAsync(PipelineMessage message, IReadOnlyList`1 pipeline, Int32 currentIndex)
         at GenericActionPipelinePolicy.ProcessAsync(PipelineMessage message, IReadOnlyList`1 pipeline, Int32 currentIndex)
         at OpenAI.GenericActionPipelinePolicy.ProcessAsync(PipelineMessage message, IReadOnlyList`1 pipeline, Int32 currentIndex)
         at System.ClientModel.Primitives.ClientPipeline.SendAsync(PipelineMessage message)
         at OpenAI.ClientPipelineExtensions.ProcessMessageAsync(ClientPipeline pipeline, PipelineMessage message, RequestOptions options)
         at OpenAI.Chat.ChatClient.CompleteChatAsync(BinaryContent content, RequestOptions options)
         at OpenAI.Chat.ChatClient.CompleteChatAsync(IEnumerable`1 messages, ChatCompletionOptions options, CancellationToken cancellationToken)
         at Microsoft.SemanticKernel.Connectors.OpenAI.ClientCore.RunRequestAsync[T](Func`1 request)
         at Microsoft.SemanticKernel.Connectors.OpenAI.ClientCore.GetChatMessageContentsAsync(String targetModel, ChatHistory chatHistory, PromptExecutionSettings executionSettings, Kernel kernel, CancellationToken cancellationToken)
         at Microsoft.SemanticKernel.ChatCompletion.ChatCompletionServiceExtensions.GetChatMessageContentAsync(IChatCompletionService chatCompletionService, String prompt, PromptExecutionSettings executionSettings, Kernel kernel, CancellationToken cancellationToken)
         at XiansAi.Flow.Router.SemanticRouterHubImpl.ChatCompletionAsync(String prompt, RouterOptions options)
         at XiansAi.Flow.Router.SemanticRouterHub.ChatCompletionAsync(String prompt, RouterOptions routerOptions, SystemActivityOptions systemActivityOptions)
         at BUZAI.Activities.LlmActivities.ConvertToTemplateFormat(DataFetchedEvent reportData) in /home/runner/work/qib/qib/BUZZAIAgent/Src/CommonActivities/LLMActivity.cs:line 109
         --- End of inner exception stack trace ---
         at BUZAI.Activities.LlmActivities.ConvertToTemplateFormat(DataFetchedEvent reportData) in /home/runner/work/qib/qib/BUZZAIAgent/Src/CommonActivities/LLMActivity.cs:line 117
         at Temporalio.Activities.ActivityDefinition.InvokeAsync(Object[] parameters)
         at Temporalio.Worker.ActivityWorker.ExecuteActivityInternalAsync(RunningActivity act, ActivityTask tsk, DataConverter dataConverter) ```
         
         
         