### PR TITLE
Refactor: rebrand XiansAI to Agentri

### DIFF
--- a/XiansAi.Lib.Src/Activity/ActivityContext.cs
+++ b/XiansAi.Lib.Src/Activity/ActivityContext.cs
@@ -1,7 +1,7 @@
 using Temporalio.Activities;
-using XiansAi.Models;
+using Agentri.Models;
 
-namespace XiansAi.Activity;
+namespace Agentri.Activity;
 public static class ActivityContext
 {
     internal static bool IsInWorkflow() 

--- a/XiansAi.Lib.Src/Activity/ActivityProxy.cs
+++ b/XiansAi.Lib.Src/Activity/ActivityProxy.cs
@@ -1,10 +1,10 @@
 using System.Reflection;
 using System.Text.Json;
 using Temporalio.Activities;
-using Server;
-using XiansAi.Logging;
+using Agentri.Server;
+using Agentri.Logging;
 
-namespace XiansAi.Activity;
+namespace Agentri.Activity;
 
 /// <summary>
 /// Activity tracker proxy that intercepts activity method calls to track and log them

--- a/XiansAi.Lib.Src/Activity/ActivityProxyFactory.cs
+++ b/XiansAi.Lib.Src/Activity/ActivityProxyFactory.cs
@@ -1,6 +1,6 @@
-using XiansAi.Logging;
+using Agentri.Logging;
 
-namespace XiansAi.Activity;
+namespace Agentri.Activity;
 
 /// <summary>
 /// Non-static class just for logger type reference

--- a/XiansAi.Lib.Src/AgentContext.cs
+++ b/XiansAi.Lib.Src/AgentContext.cs
@@ -1,7 +1,7 @@
 using Temporalio.Activities;
 using Temporalio.Workflows;
-using XiansAi.Models;
-using XiansAi.Server;
+using Agentri.Models;
+using Agentri.Server;
 using Temporal;
 
 public class AgentContext

--- a/XiansAi.Lib.Src/Flow/AbstractFlow.cs
+++ b/XiansAi.Lib.Src/Flow/AbstractFlow.cs
@@ -1,9 +1,9 @@
 using Temporalio.Workflows;
-using XiansAi.Messaging;
-using XiansAi.Memory;
+using Agentri.Messaging;
+using Agentri.Memory;
 using Temporal;
 
-namespace XiansAi.Flow;
+namespace Agentri.Flow;
 
 /// <summary>
 /// Base class for all workflow implementations providing common functionality.

--- a/XiansAi.Lib.Src/Flow/Agent.cs
+++ b/XiansAi.Lib.Src/Flow/Agent.cs
@@ -1,8 +1,8 @@
-using Server;
-using XiansAi.Models;
+using Agentri.Server;
+using Agentri.Models;
 using Temporal;
 
-namespace XiansAi.Flow;
+namespace Agentri.Flow;
 
 /// <summary>
 /// Main entry point for creating and managing flows and bots.

--- a/XiansAi.Lib.Src/Flow/Bot.cs
+++ b/XiansAi.Lib.Src/Flow/Bot.cs
@@ -1,6 +1,6 @@
 using Microsoft.SemanticKernel;
 
-namespace XiansAi.Flow;
+namespace Agentri.Flow;
 
 /// <summary>
 /// Interface for type-erased bot storage.

--- a/XiansAi.Lib.Src/Flow/ChatHandler.cs
+++ b/XiansAi.Lib.Src/Flow/ChatHandler.cs
@@ -1,10 +1,10 @@
 using Temporalio.Workflows;
-using XiansAi.Messaging;
-using XiansAi.Logging;
-using XiansAi.Flow.Router;
-using XiansAi.Knowledge;
+using Agentri.Messaging;
+using Agentri.Logging;
+using Agentri.Flow.Router;
+using Agentri.Knowledge;
 
-namespace XiansAi.Flow;
+namespace Agentri.Flow;
 
 // Define delegate for message listening
 public delegate Task MessageListenerDelegate(MessageThread messageThread);

--- a/XiansAi.Lib.Src/Flow/DataHandler.cs
+++ b/XiansAi.Lib.Src/Flow/DataHandler.cs
@@ -1,10 +1,10 @@
 using System.Collections.Concurrent;
 using Temporalio.Exceptions;
 using Temporalio.Workflows;
-using XiansAi.Logging;
-using XiansAi.Messaging;
+using Agentri.Logging;
+using Agentri.Messaging;
 
-namespace XiansAi.Flow;
+namespace Agentri.Flow;
 public class DataHandler : SafeHandler
 {
     private readonly MessageHub _messageHub;

--- a/XiansAi.Lib.Src/Flow/DynamicMethodInvoker.cs
+++ b/XiansAi.Lib.Src/Flow/DynamicMethodInvoker.cs
@@ -1,10 +1,10 @@
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using XiansAi.Messaging;
-using XiansAi.Logging;
+using Agentri.Messaging;
+using Agentri.Logging;
 
-namespace XiansAi.Flow;
+namespace Agentri.Flow;
 
 public class DynamicMethodInvokerLogger{}
 

--- a/XiansAi.Lib.Src/Flow/Flow.cs
+++ b/XiansAi.Lib.Src/Flow/Flow.cs
@@ -1,5 +1,5 @@
 
-namespace XiansAi.Flow;
+namespace Agentri.Flow;
 
 /// <summary>
 /// Interface for type-erased flow storage.

--- a/XiansAi.Lib.Src/Flow/FlowBase.cs
+++ b/XiansAi.Lib.Src/Flow/FlowBase.cs
@@ -1,9 +1,9 @@
 using System.Reflection;
 using Temporal;
 using Temporalio.Workflows;
-using XiansAi.Flow.Router;
+using Agentri.Flow.Router;
 
-namespace XiansAi.Flow;
+namespace Agentri.Flow;
 
 public abstract class FlowBase : AbstractFlow
 {

--- a/XiansAi.Lib.Src/Flow/IChatInterceptor.cs
+++ b/XiansAi.Lib.Src/Flow/IChatInterceptor.cs
@@ -1,6 +1,6 @@
-using XiansAi.Messaging;
+using Agentri.Messaging;
 
-namespace XiansAi.Flow;
+namespace Agentri.Flow;
 
 public interface IChatInterceptor
 {

--- a/XiansAi.Lib.Src/Flow/IKernelModifier.cs
+++ b/XiansAi.Lib.Src/Flow/IKernelModifier.cs
@@ -1,6 +1,6 @@
 using Microsoft.SemanticKernel;
 
-namespace XiansAi.Flow;
+namespace Agentri.Flow;
 
 public interface IKernelModifier
 {

--- a/XiansAi.Lib.Src/Flow/Runner.cs
+++ b/XiansAi.Lib.Src/Flow/Runner.cs
@@ -1,13 +1,13 @@
 using System.Reflection;
 using System.Collections.Concurrent;
-using Server;
+using Agentri.Server;
 using Temporal;
 using Temporalio.Workflows;
-using XiansAi.Activity;
-using XiansAi.Models;
+using Agentri.Activity;
+using Agentri.Models;
 using Microsoft.Extensions.Logging;
 
-namespace XiansAi.Flow;
+namespace Agentri.Flow;
 
 /// <summary>
 /// Non-generic static helper class for accessing runner registry.

--- a/XiansAi.Lib.Src/Flow/ScheduleHandler.cs
+++ b/XiansAi.Lib.Src/Flow/ScheduleHandler.cs
@@ -1,9 +1,9 @@
 using System.Reflection;
 using Temporalio.Workflows;
-using XiansAi.Logging;
+using Agentri.Logging;
 using NCrontab;
-using XiansAi.Knowledge;
-using XiansAi.Flow;
+using Agentri.Knowledge;
+using Agentri.Flow;
 
 public class ScheduleHandler: SafeHandler
 {

--- a/XiansAi.Lib.Src/Flow/SemanticRouter/ChatHistoryReducer.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/ChatHistoryReducer.cs
@@ -3,7 +3,7 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using System.Text;
 
-namespace XiansAi.Flow.Router;
+namespace Agentri.Flow.Router;
 
 /// <summary>
 /// Provides chat history reduction strategies to keep conversations within token limits.

--- a/XiansAi.Lib.Src/Flow/SemanticRouter/LlmConfigurationResolver.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/LlmConfigurationResolver.cs
@@ -1,7 +1,7 @@
 using System.Threading.Tasks;
-using Server;
+using Agentri.Server;
 
-namespace XiansAi.Flow.Router;
+namespace Agentri.Flow.Router;
 
 /// <summary>
 /// Configuration resolver for LLM settings with fallback hierarchy:

--- a/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/AvailablePlugins.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/AvailablePlugins.cs
@@ -1,4 +1,4 @@
-namespace XiansAi.Flow.Router.Plugins;
+namespace Agentri.Flow.Router.Plugins;
 
 /// <summary>
 /// Provides a list of predefined plugins that are available for use with the DynamicOrchestrator.

--- a/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/CapabilityAttribute.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/CapabilityAttribute.cs
@@ -1,4 +1,4 @@
-namespace XiansAi.Flow.Router.Plugins;
+namespace Agentri.Flow.Router.Plugins;
 
 /// <summary>
 /// Marks a method as a capability so that it will be registered automatically.

--- a/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/CapabilityKnowledgeLoader.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/CapabilityKnowledgeLoader.cs
@@ -1,8 +1,8 @@
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
-using XiansAi.Knowledge;
+using Agentri.Knowledge;
 
-namespace XiansAi.Flow.Router.Plugins;
+namespace Agentri.Flow.Router.Plugins;
 
 /// <summary>
 /// Provides functionality to load capability knowledge from JSON content via the KnowledgeLoader.

--- a/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/CapabilityKnowledgeModel.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/CapabilityKnowledgeModel.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace XiansAi.Flow.Router.Plugins;
+namespace Agentri.Flow.Router.Plugins;
 
 /// <summary>
 /// Represents the structure of the JSON file referenced by CapabilityKnowledgeAttribute.

--- a/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/DatePlugin.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/DatePlugin.cs
@@ -1,4 +1,4 @@
-namespace XiansAi.Flow.Router.Plugins;
+namespace Agentri.Flow.Router.Plugins;
 
 /// <summary>
 /// A plugin that provides date and time functionalities. 

--- a/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/ParameterAttribute.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/ParameterAttribute.cs
@@ -1,5 +1,5 @@
 
-namespace XiansAi.Flow.Router.Plugins;
+namespace Agentri.Flow.Router.Plugins;
 
 /// <summary>
 /// Marks a parameter with a name and description for use in kernel functions.

--- a/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/PluginBase.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/PluginBase.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace XiansAi.Flow.Router.Plugins;
+namespace Agentri.Flow.Router.Plugins;
 
 /// <summary>
 /// Base class for all plugins that provides common functionality.

--- a/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/PluginReader.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/PluginReader.cs
@@ -4,11 +4,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using XiansAi.Activity;
-using XiansAi.Knowledge;
-using XiansAi.Messaging;
+using Agentri.Activity;
+using Agentri.Knowledge;
+using Agentri.Messaging;
 
-namespace XiansAi.Flow.Router.Plugins;
+namespace Agentri.Flow.Router.Plugins;
 
 internal class PluginReaderLogger { }
 

--- a/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/ReturnsAttribute.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/Plugins/ReturnsAttribute.cs
@@ -1,4 +1,4 @@
-namespace XiansAi.Flow.Router.Plugins;
+namespace Agentri.Flow.Router.Plugins;
 
 /// <summary>
 /// Marks a method as a return value for a capability.

--- a/XiansAi.Lib.Src/Flow/SemanticRouter/RouterOptions.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/RouterOptions.cs
@@ -1,5 +1,5 @@
 
-namespace XiansAi.Flow.Router;
+namespace Agentri.Flow.Router;
 
 /// <summary>
 /// Configuration options for the DynamicOrchestrator.

--- a/XiansAi.Lib.Src/Flow/SemanticRouter/SemanticRouterHub.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/SemanticRouterHub.cs
@@ -1,9 +1,9 @@
 using Temporal;
 using Temporalio.Activities;
 using Temporalio.Workflows;
-using XiansAi.Messaging;
+using Agentri.Messaging;
 
-namespace XiansAi.Flow.Router;
+namespace Agentri.Flow.Router;
 
 /// <summary>
 /// Public API for semantic routing operations within Temporal workflows.

--- a/XiansAi.Lib.Src/Flow/SemanticRouter/SemanticRouterImpl.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/SemanticRouterImpl.cs
@@ -3,12 +3,12 @@ using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.OpenAI;
 using Microsoft.SemanticKernel.Agents;
-using XiansAi.Messaging;
-using XiansAi.Flow.Router.Plugins;
+using Agentri.Messaging;
+using Agentri.Flow.Router.Plugins;
 using Microsoft.Extensions.DependencyInjection;
 
 
-namespace XiansAi.Flow.Router;
+namespace Agentri.Flow.Router;
 
 /// <summary>
 /// Core implementation of the semantic router functionality.

--- a/XiansAi.Lib.Src/Flow/TypeActivator.cs
+++ b/XiansAi.Lib.Src/Flow/TypeActivator.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 
-namespace XiansAi.Flow;
+namespace Agentri.Flow;
 
 internal static class TypeActivator
 {

--- a/XiansAi.Lib.Src/Flow/WebhookHandler.cs
+++ b/XiansAi.Lib.Src/Flow/WebhookHandler.cs
@@ -1,7 +1,7 @@
 using Temporalio.Workflows;
-using XiansAi.Logging;
+using Agentri.Logging;
 
-namespace XiansAi.Flow;
+namespace Agentri.Flow;
 
 /// <summary>
 /// Handles chat message processing and conversation management for flows

--- a/XiansAi.Lib.Src/Knowledge/KnowledgeAttribute.cs
+++ b/XiansAi.Lib.Src/Knowledge/KnowledgeAttribute.cs
@@ -1,4 +1,4 @@
-namespace XiansAi.Knowledge;
+namespace Agentri.Knowledge;
 
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = false)]
 public sealed class KnowledgeAttribute: Attribute

--- a/XiansAi.Lib.Src/Knowledge/KnowledgeHub.cs
+++ b/XiansAi.Lib.Src/Knowledge/KnowledgeHub.cs
@@ -1,6 +1,6 @@
 using Temporalio.Workflows;
 
-namespace XiansAi.Knowledge;
+namespace Agentri.Knowledge;
 
 public static class KnowledgeHub
 {

--- a/XiansAi.Lib.Src/Knowledge/KnowledgeLoader.cs
+++ b/XiansAi.Lib.Src/Knowledge/KnowledgeLoader.cs
@@ -1,7 +1,7 @@
-using Server;
-using XiansAi.Logging;
+using Agentri.Server;
+using Agentri.Logging;
 
-namespace XiansAi.Knowledge;
+namespace Agentri.Knowledge;
 
 /// <summary>
 /// Defines a service for loading instructions from either a server or local filesystem.

--- a/XiansAi.Lib.Src/Knowledge/KnowledgeSync.cs
+++ b/XiansAi.Lib.Src/Knowledge/KnowledgeSync.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Logging;
-using Server;
+using Agentri.Server;
 
-namespace XiansAi.Knowledge;
+namespace Agentri.Knowledge;
 
 public class KnowledgeSync
 {

--- a/XiansAi.Lib.Src/Knowledge/KnowledgeUpdater.cs
+++ b/XiansAi.Lib.Src/Knowledge/KnowledgeUpdater.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Logging;
-using Server;
-
-namespace XiansAi.Knowledge;
+using Agentri.Server;
+namespace Agentri.Knowledge;
 
 /// <summary>
 /// Defines a service for updating knowledges either on a server or locally.

--- a/XiansAi.Lib.Src/Logging/ApiLoggerProvider.cs
+++ b/XiansAi.Lib.Src/Logging/ApiLoggerProvider.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Logging;
-using XiansAi.Models;
-namespace XiansAi.Logging;
+using Agentri.Models;
+namespace Agentri.Logging;
 
 public class ApiLoggerProvider : ILoggerProvider
 {

--- a/XiansAi.Lib.Src/Logging/Logger.cs
+++ b/XiansAi.Lib.Src/Logging/Logger.cs
@@ -3,7 +3,7 @@ using Temporalio.Activities;
 using Temporalio.Workflows;
 using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
-namespace XiansAi.Logging;
+namespace Agentri.Logging;
 
 public class Logger<T>
 {

--- a/XiansAi.Lib.Src/Logging/LoggingServices.cs
+++ b/XiansAi.Lib.Src/Logging/LoggingServices.cs
@@ -1,11 +1,11 @@
-using Server;
+using Agentri.Server;
 using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using XiansAi.Models;
+using Agentri.Models;
 using System.Net.Http.Json;
 
-namespace XiansAi.Logging;
+namespace Agentri.Logging;
 
 /// <summary>
 /// Static class providing logging service management and shutdown handling

--- a/XiansAi.Lib.Src/Memory/DocumentModels.cs
+++ b/XiansAi.Lib.Src/Memory/DocumentModels.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace XiansAi.Memory;
+namespace Agentri.Memory;
 
 /// <summary>
 /// Represents a document stored in the database with metadata.

--- a/XiansAi.Lib.Src/Memory/DocumentStore.cs
+++ b/XiansAi.Lib.Src/Memory/DocumentStore.cs
@@ -1,10 +1,10 @@
 using Microsoft.Extensions.Logging;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Server;
+using Agentri.Server;
 using Temporalio.Workflows;
 
-namespace XiansAi.Memory;
+namespace Agentri.Memory;
 
 /// <summary>
 /// Implementation of document storage operations using the secure API backend.

--- a/XiansAi.Lib.Src/Memory/IDocumentStore.cs
+++ b/XiansAi.Lib.Src/Memory/IDocumentStore.cs
@@ -1,4 +1,4 @@
-namespace XiansAi.Memory;
+namespace Agentri.Memory;
 
 /// <summary>
 /// Provides document storage operations for AI agents to save, retrieve, and manage JSON documents.

--- a/XiansAi.Lib.Src/Memory/MemoryHub.cs
+++ b/XiansAi.Lib.Src/Memory/MemoryHub.cs
@@ -1,6 +1,6 @@
-using Server;
+using Agentri.Server;
 
-namespace XiansAi.Memory;
+namespace Agentri.Memory;
 
 public static class MemoryHub
 {

--- a/XiansAi.Lib.Src/Messenging/Agent2Agent.cs
+++ b/XiansAi.Lib.Src/Messenging/Agent2Agent.cs
@@ -1,9 +1,9 @@
 using Temporal;
 using Temporalio.Activities;
 using Temporalio.Workflows;
-using XiansAi.Flow;
+using Agentri.Flow;
 
-namespace XiansAi.Messaging;
+namespace Agentri.Messaging;
 
 /// <summary>
 /// Interface for agent-to-agent communication within the XiansAi workflow system.

--- a/XiansAi.Lib.Src/Messenging/Agent2User.cs
+++ b/XiansAi.Lib.Src/Messenging/Agent2User.cs
@@ -1,7 +1,7 @@
 using Temporal;
 using Temporalio.Workflows;
 
-namespace XiansAi.Messaging;
+namespace Agentri.Messaging;
 
 interface IAgent2User {
     /// <summary>

--- a/XiansAi.Lib.Src/Messenging/MessageHub.cs
+++ b/XiansAi.Lib.Src/Messenging/MessageHub.cs
@@ -2,9 +2,9 @@ using System.Collections.Concurrent;
 using System.Text.Json;
 using Temporal;
 using Temporalio.Workflows;
-using XiansAi.Logging;
+using Agentri.Logging;
 
-namespace XiansAi.Messaging;
+namespace Agentri.Messaging;
 
 public delegate Task ConversationReceivedAsyncHandler(MessageThread conversation);
 public delegate void ConversationReceivedHandler(MessageThread conversation);

--- a/XiansAi.Lib.Src/Messenging/MessageThread.cs
+++ b/XiansAi.Lib.Src/Messenging/MessageThread.cs
@@ -4,7 +4,7 @@ using Temporalio.Workflows;
 using System.Text.Json.Serialization;
 using Temporal;
 
-namespace XiansAi.Messaging;
+namespace Agentri.Messaging;
 public interface IMessageThread
 {
     Task<List<DbMessage>> FetchThreadHistory(int page = 1, int pageSize = 10);

--- a/XiansAi.Lib.Src/Messenging/Models.cs
+++ b/XiansAi.Lib.Src/Messenging/Models.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
     
-namespace XiansAi.Messaging;
+namespace Agentri.Messaging;
 public class MessageSignal
 {
     public required MessagePayload Payload { get; set; }

--- a/XiansAi.Lib.Src/Models/ActivityDefinition.cs
+++ b/XiansAi.Lib.Src/Models/ActivityDefinition.cs
@@ -1,4 +1,4 @@
-namespace XiansAi.Models;
+namespace Agentri.Models;
 using System.Text.Json.Serialization;
 
 public class ActivityDefinition

--- a/XiansAi.Lib.Src/Models/ActivityHistory.cs
+++ b/XiansAi.Lib.Src/Models/ActivityHistory.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace XiansAi.Models;
+namespace Agentri.Models;
 
 public class ActivityHistory
 {

--- a/XiansAi.Lib.Src/Models/AgentInfo.cs
+++ b/XiansAi.Lib.Src/Models/AgentInfo.cs
@@ -1,4 +1,4 @@
-namespace XiansAi.Models;
+namespace Agentri.Models;
 
 [Obsolete("Use of AgentInfo is now obsolete. Refer to the online documentation for more information on how to create an agent.")]
 public class AgentInfo

--- a/XiansAi.Lib.Src/Models/CertificateInfo.cs
+++ b/XiansAi.Lib.Src/Models/CertificateInfo.cs
@@ -1,6 +1,6 @@
 using System.Security.Cryptography.X509Certificates;
 
-namespace XiansAi.Models;
+namespace Agentri.Models;
 
 public class CertificateInfo
 {

--- a/XiansAi.Lib.Src/Models/FlowDefinition.cs
+++ b/XiansAi.Lib.Src/Models/FlowDefinition.cs
@@ -2,7 +2,7 @@
 using System.Reflection;
 using System.Text.Json.Serialization;
 
-namespace XiansAi.Models;
+namespace Agentri.Models;
 
 public class FlowDefinition
 {

--- a/XiansAi.Lib.Src/Models/Knowledge.cs
+++ b/XiansAi.Lib.Src/Models/Knowledge.cs
@@ -1,4 +1,4 @@
-namespace XiansAi.Models;
+namespace Agentri.Models;
 
 public class Knowledge
 {

--- a/XiansAi.Lib.Src/Models/Log.cs
+++ b/XiansAi.Lib.Src/Models/Log.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Logging;
 
-namespace XiansAi.Models
+namespace Agentri.Models
 {
     public class Log
     {

--- a/XiansAi.Lib.Src/PlatformConfig.cs
+++ b/XiansAi.Lib.Src/PlatformConfig.cs
@@ -1,4 +1,4 @@
-namespace XiansAi;
+namespace Agentri;
 
 public static class PlatformConfig
 {

--- a/XiansAi.Lib.Src/Server/ActivityUploader.cs
+++ b/XiansAi.Lib.Src/Server/ActivityUploader.cs
@@ -1,9 +1,9 @@
 using Microsoft.Extensions.Logging;
 using System.Net.Http.Json;
 using System.Text.Json;
-using XiansAi.Models;
+using Agentri.Models;
 
-namespace Server;
+namespace Agentri.Server;
 
 public class ActivityUploader
 {

--- a/XiansAi.Lib.Src/Server/CertificateReader.cs
+++ b/XiansAi.Lib.Src/Server/CertificateReader.cs
@@ -1,9 +1,9 @@
 using System.Security.Cryptography.X509Certificates;
 using System.Collections.Concurrent;
-using XiansAi.Models;
+using Agentri.Models;
 using Microsoft.Extensions.Logging;
 
-namespace XiansAi.Server;
+namespace Agentri.Server;
 
 public class CertificateReader
 {

--- a/XiansAi.Lib.Src/Server/FlowDefinitionUploader.cs
+++ b/XiansAi.Lib.Src/Server/FlowDefinitionUploader.cs
@@ -4,12 +4,12 @@ using System.Reflection;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using System.Text.Encodings.Web;
-using XiansAi.Flow;
-using XiansAi.Knowledge;
-using XiansAi.Models;
+using Agentri.Flow;
+using Agentri.Knowledge;
+using Agentri.Models;
 using System.Security.Cryptography;
 
-namespace Server;
+namespace Agentri.Server;
 
 /// <summary>
 /// Defines a service for uploading flow definitions to the server.

--- a/XiansAi.Lib.Src/Server/KnowledgeService.cs
+++ b/XiansAi.Lib.Src/Server/KnowledgeService.cs
@@ -3,9 +3,9 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Encodings.Web;
 using System.Text.Json;
-using XiansAi.Models;
+using Agentri.Models;
 
-namespace Server;
+namespace Agentri.Server;
 
 public class KnowledgeService
 {
@@ -23,7 +23,7 @@ public class KnowledgeService
     /// </summary>
     /// <param name="knowledgeName">The name of the knowledge to load</param>
     /// <returns>The loaded knowledge, or null if not found</returns>
-    public async Task<Knowledge?> GetKnowledgeFromServer(string knowledgeName, string agent)
+    public async Task<Models.Knowledge?> GetKnowledgeFromServer(string knowledgeName, string agent)
     {
         if (!SecureApi.IsReady)
         {
@@ -65,7 +65,7 @@ public class KnowledgeService
     /// </summary>
     /// <param name="knowledge">The knowledge to upload</param>
     /// <returns>True if upload was successful</returns>
-    public async Task<bool> UploadKnowledgeToServer(Knowledge knowledge)
+    public async Task<bool> UploadKnowledgeToServer(Models.Knowledge knowledge)
     {
         if (!SecureApi.IsReady)
         {
@@ -108,7 +108,7 @@ public class KnowledgeService
     /// <summary>
     /// Parses the server response into a Knowledge object
     /// </summary>
-    private async Task<Knowledge?> ParseKnowledgeResponse(HttpResponseMessage httpResult)
+    private async Task<Models.Knowledge?> ParseKnowledgeResponse(HttpResponseMessage httpResult)
     {
         var response = await httpResult.Content.ReadAsStringAsync();
 
@@ -120,7 +120,7 @@ public class KnowledgeService
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase
             };
             
-            var knowledge = JsonSerializer.Deserialize<Knowledge>(response, options);
+            var knowledge = JsonSerializer.Deserialize<Models.Knowledge>(response, options);
 
             if (knowledge?.Content == null || knowledge.Name == null)
             {

--- a/XiansAi.Lib.Src/Server/ObjectCache.cs
+++ b/XiansAi.Lib.Src/Server/ObjectCache.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Logging;
 using System.Net.Http.Json;
 
-namespace Server;
+namespace Agentri.Server;
 
 public interface IObjectCache
 {

--- a/XiansAi.Lib.Src/Server/ResourceUploader.cs
+++ b/XiansAi.Lib.Src/Server/ResourceUploader.cs
@@ -1,7 +1,7 @@
-using XiansAi.Knowledge;
-using XiansAi.Logging;
+using Agentri.Knowledge;
+using Agentri.Logging;
 
-namespace Server;
+namespace Agentri.Server;
 
 /// <summary>
 /// Defines a service for uploading flow definitions to the server.

--- a/XiansAi.Lib.Src/Server/SecureApi.cs
+++ b/XiansAi.Lib.Src/Server/SecureApi.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 using System.Net;
 using System.Net.Sockets;
 
-namespace Server;
+namespace Agentri.Server;
 
 /// <summary>
 /// Defines a client for secure API communications.

--- a/XiansAi.Lib.Src/Server/SettingsService.cs
+++ b/XiansAi.Lib.Src/Server/SettingsService.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Logging;
 using System.Net;
 using System.Text.Json;
 
-namespace Server;
+namespace Agentri.Server;
 
 
 public class ServerSettings

--- a/XiansAi.Lib.Src/Server/SystemActivities.cs
+++ b/XiansAi.Lib.Src/Server/SystemActivities.cs
@@ -1,16 +1,16 @@
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
-using Server;
+using Agentri.Server;
 using Temporalio.Activities;
 using Temporalio.Workflows;
-using XiansAi.Knowledge;
-using XiansAi.Messaging;
-using XiansAi.Models;
-using XiansAi.Flow.Router;
-using XiansAi.Flow;
+using Agentri.Knowledge;
+using Agentri.Messaging;
+using Agentri.Models;
+using Agentri.Flow.Router;
+using Agentri.Flow;
 using System.Text.Json;
 using Temporal;
-using XiansAi.Memory;
+using Agentri.Memory;
 using Temporalio.Common;
 
 public class SendMessageResponse

--- a/XiansAi.Lib.Src/Server/ThreadHistoryService.cs
+++ b/XiansAi.Lib.Src/Server/ThreadHistoryService.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Temporalio.Workflows;
-using XiansAi.Messaging;
+using Agentri.Messaging;
 
 public class ThreadHistoryService
 {

--- a/XiansAi.Lib.Src/Temporal/CommandLineHelper.cs
+++ b/XiansAi.Lib.Src/Temporal/CommandLineHelper.cs
@@ -1,8 +1,8 @@
 using Microsoft.Extensions.Logging;
-using XiansAi.Flow;
-using XiansAi.Activity;
-using XiansAi.Logging;
-using Server;
+using Agentri.Flow;
+using Agentri.Activity;
+using Agentri.Logging;
+using Agentri.Server;
 
 namespace Temporal;
 

--- a/XiansAi.Lib.Src/Temporal/LoggingUtils.cs
+++ b/XiansAi.Lib.Src/Temporal/LoggingUtils.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
-using XiansAi.Logging;
+using Agentri.Logging;
 
 namespace Temporal;
 

--- a/XiansAi.Lib.Src/Temporal/SubWorkflowService.cs
+++ b/XiansAi.Lib.Src/Temporal/SubWorkflowService.cs
@@ -1,5 +1,5 @@
 using Temporalio.Workflows;
-using XiansAi.Logging;
+using Agentri.Logging;
 
 namespace Temporal;
 

--- a/XiansAi.Lib.Src/Temporal/TemporalClientService.cs
+++ b/XiansAi.Lib.Src/Temporal/TemporalClientService.cs
@@ -1,5 +1,5 @@
 using Microsoft.Extensions.Logging;
-using Server;
+using Agentri.Server;
 using Temporalio.Client;
 
 namespace Temporal;

--- a/XiansAi.Lib.Src/Temporal/WorkerService.cs
+++ b/XiansAi.Lib.Src/Temporal/WorkerService.cs
@@ -1,9 +1,8 @@
 
 using Temporalio.Worker;
-using Server;
-using XiansAi.Server;
-using XiansAi.Flow;
-using XiansAi;
+using Agentri.Server;
+using Agentri.Flow;
+using Agentri;
 using Microsoft.Extensions.Logging;
 
 namespace Temporal;

--- a/XiansAi.Lib.Src/XiansAi.Lib.csproj
+++ b/XiansAi.Lib.Src/XiansAi.Lib.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <RootNamespace>XiansAi.Lib</RootNamespace>
+    <RootNamespace>Agentri.SDK</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,13 +14,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>XiansAi.Lib</PackageId>
+    <PackageId>Agentri.SDK</PackageId>
     <Version>2.4.3</Version>
     <Authors>99x</Authors>
-    <Description>This is a library for the Xians.Ai flow projects. This LIbrary is used by the Flows. It contains the base classes, interfaces and other utilities for creating and running Flows.</Description>
-    <PackageProjectUrl>https://github.com/XiansAiPlatform/XiansAi.Lib</PackageProjectUrl>
+    <Description>This is a library for the Agentri flow projects. This LIbrary is used by the Flows. It contains the base classes, interfaces and other utilities for creating and running Flows.</Description>
+     <PackageProjectUrl>https://github.com/XiansAiPlatform/XiansAi.Lib</PackageProjectUrl>
     <RepositoryUrl>https://github.com/XiansAiPlatform/XiansAi.Lib</RepositoryUrl>
-    <PackageTags>Xians AI</PackageTags>
+    <PackageTags>Agentri AI</PackageTags>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <Copyright>Copyright (c) 99x</Copyright>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/XiansAi.Lib.Src/docs/NUGET.md
+++ b/XiansAi.Lib.Src/docs/NUGET.md
@@ -1,6 +1,6 @@
 # NuGet Package Documentation
 
-This document provides comprehensive instructions for building, publishing, and consuming the XiansAi.Lib NuGet package.
+This document provides comprehensive instructions for building, publishing, and consuming the Agentri.SDK NuGet package.
 
 ## Table of Contents
 
@@ -159,9 +159,9 @@ Add this to your `.csproj` file:
 ### Using in Code
 
 ```csharp
-using XiansAi.Lib;
-using XiansAi.Lib.Flow;
-using XiansAi.Lib.Knowledge;
+using Agentri.SDK;
+using Agentri.Flow;
+using Agentri.Knowledge;
 
 // Example usage
 var agent = new Agent();
@@ -227,7 +227,7 @@ var knowledgeHub = new KnowledgeHub();
 3. **Test the package:**
 
    ```csharp
-   using XiansAi.Lib;
+   using Agentri.SDK;
    
    Console.WriteLine("Testing XiansAi.Lib package");
    ```

--- a/XiansAi.Lib.Tests/IntegrationTests/InstructionLoaderTests.cs
+++ b/XiansAi.Lib.Tests/IntegrationTests/InstructionLoaderTests.cs
@@ -1,11 +1,11 @@
 using System.Net;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
-using Server;
+using Agentri.Server;
 using DotNetEnv;
-using XiansAi.Knowledge;
+using Agentri.Knowledge;
 
-namespace XiansAi.Lib.Tests.IntegrationTests;
+namespace Agentri.SDK.Tests.IntegrationTests;
 
 [Collection("SecureApi Tests")]
 public class InstructionLoaderTests

--- a/XiansAi.Lib.Tests/IntegrationTests/SecureApiTests.cs
+++ b/XiansAi.Lib.Tests/IntegrationTests/SecureApiTests.cs
@@ -1,9 +1,9 @@
 using Microsoft.Extensions.Logging;
-using Server;
+using Agentri.Server;
 using DotNetEnv;
 using System.Reflection;
 
-namespace XiansAi.Lib.Tests.IntegrationTests;
+namespace Agentri.SDK.Tests.IntegrationTests;
 
 [Collection("SecureApi Tests")]
 public class SecureApiTests 

--- a/XiansAi.Lib.Tests/IntegrationTests/SystemActivitiesTests.cs
+++ b/XiansAi.Lib.Tests/IntegrationTests/SystemActivitiesTests.cs
@@ -1,9 +1,9 @@
 using Microsoft.Extensions.Logging;
-using Server;
+using Agentri.Server;
 using DotNetEnv;
 
 
-namespace XiansAi.Lib.Tests.IntegrationTests;
+namespace Agentri.SDK.Tests.IntegrationTests;
 
 [Collection("SecureApi Tests")]
 public class SystemActivitiesTests

--- a/XiansAi.Lib.Tests/UnitTests/Flow/MessengerTests.cs
+++ b/XiansAi.Lib.Tests/UnitTests/Flow/MessengerTests.cs
@@ -1,7 +1,7 @@
-using XiansAi.Messaging;
+using Agentri.Messaging;
 
 
-namespace XiansAi.Lib.Tests.UnitTests.Flow
+namespace Agentri.SDK.Tests.UnitTests.Flow
 {
     /*
     dotnet test --filter "FullyQualifiedName~MessengerTests"

--- a/XiansAi.Lib.Tests/UnitTests/Router/Plugins/CapabilityKnowledgeLoaderTests.cs
+++ b/XiansAi.Lib.Tests/UnitTests/Router/Plugins/CapabilityKnowledgeLoaderTests.cs
@@ -1,8 +1,8 @@
 using System.Reflection;
-using XiansAi.Flow.Router.Plugins;
+using Agentri.Flow.Router.Plugins;
 
 
-namespace XiansAi.Lib.Tests.UnitTests.Router.Plugins
+namespace Agentri.SDK.Tests.UnitTests.Router.Plugins
 {
     /*
     dotnet test --filter "FullyQualifiedName~Router.Plugins.CapabilityKnowledgeLoaderTests"

--- a/XiansAi.Lib.Tests/UnitTests/Router/Plugins/PluginBaseTests.cs
+++ b/XiansAi.Lib.Tests/UnitTests/Router/Plugins/PluginBaseTests.cs
@@ -1,6 +1,6 @@
-using XiansAi.Flow.Router.Plugins;
+using Agentri.Flow.Router.Plugins;
 
-namespace XiansAi.Lib.Tests.UnitTests.Router.Plugins
+namespace Agentri.SDK.Tests.UnitTests.Router.Plugins
 {
     /*
     dotnet test --filter "FullyQualifiedName~Router.Plugins.PluginBaseTests"

--- a/XiansAi.Lib.Tests/UnitTests/Temporal/WorkflowIdentifierTests.cs
+++ b/XiansAi.Lib.Tests/UnitTests/Temporal/WorkflowIdentifierTests.cs
@@ -1,6 +1,6 @@
 using Temporal;
 
-namespace XiansAi.Lib.Tests.UnitTests.Temporal
+namespace Agentri.SDK.Tests.UnitTests.Temporal
 {
     /*
     dotnet test --filter "FullyQualifiedName~WorkflowIdentifierTests"


### PR DESCRIPTION
- Renamed all namespaces from XiansAI to Agentri.
- Rename PackageId and RootNamespace from XiansAI.Lib to Agentri.SDK