### PR TITLE
Update IKernelModifier and SemanticRouterImpl to include messageThread parameter for kernel modification

### DIFF
--- a/XiansAi.Lib.Src/Flow/IKernelModifier.cs
+++ b/XiansAi.Lib.Src/Flow/IKernelModifier.cs
@@ -1,8 +1,9 @@
 using Microsoft.SemanticKernel;
+using XiansAi.Messaging;
 
 namespace XiansAi.Flow;
 
 public interface IKernelModifier
 {
-    Task<Kernel> ModifyKernelAsync(Kernel kernel);
+    Task<Kernel> ModifyKernelAsync(Kernel kernel, MessageThread messageThread);
 }

--- a/XiansAi.Lib.Src/Flow/SemanticRouter/SemanticRouterImpl.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/SemanticRouterImpl.cs
@@ -237,7 +237,7 @@ internal class SemanticRouterHubImpl : IDisposable
             try
             {
                 _logger.LogDebug("Modifying kernel with {KernelModifierType}", kernelModifier.GetType().Name);
-                kernel = await kernelModifier.ModifyKernelAsync(kernel);
+                kernel = await kernelModifier.ModifyKernelAsync(kernel, messageThread);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
- Modified IKernelModifier interface to accept a MessageThread parameter in ModifyKernelAsync method, enhancing context during kernel modifications.
- Updated SemanticRouterImpl to pass the messageThread when calling ModifyKernelAsync, improving the integration of message context in kernel processing.