### PR TITLE
Update NuGet publish workflow to correct working directory path

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -9,7 +9,7 @@ on:
 env:
   PACKAGE_NAME: XiansAi.Lib
   NUGET_SOURCE: https://api.nuget.org/v3/index.json
-  WORK_DIR: ./XiansAi.Lib
+  WORK_DIR: ./Xians.Lib
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
- Changed the WORK_DIR environment variable in nuget-publish.yml from './XiansAi.Lib' to './Xians.Lib' to ensure accurate directory reference for the NuGet package publishing process.