### PR TITLE
Update NuGet publish workflow to correct package name

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:  # Allow manual triggering
 
 env:
-  PACKAGE_NAME: XiansAi.Lib
+  PACKAGE_NAME: Xians.Lib
   NUGET_SOURCE: https://api.nuget.org/v3/index.json
   WORK_DIR: ./Xians.Lib
 
@@ -56,7 +56,7 @@ jobs:
       
     - name: Run tests
       run: dotnet test -c Release --no-build --verbosity normal
-      working-directory: ./XiansAi.Lib.Tests
+      working-directory: ./Xians.Lib.Tests
       
     - name: Pack NuGet packages
       run: |


### PR DESCRIPTION
- Changed the PACKAGE_NAME environment variable in nuget-publish.yml from 'XiansAi.Lib' to 'Xians.Lib' for consistency with the project structure.
- Updated the working directory path for tests from './XiansAi.Lib.Tests' to './Xians.Lib.Tests' to align with the new package name.