### PR TITLE
Add local knowledge tracking and update README

### DIFF
--- a/Xians.Lib/README.md
+++ b/Xians.Lib/README.md
@@ -2,26 +2,16 @@
 
 A robust .NET library for establishing HTTP and Temporal server connections with built-in resilience, retry logic, and health monitoring.
 
-## Features
+## Releases
 
-### HTTP Client Service
-- ✅ Certificate-based and API key authentication
-- ✅ Automatic retry with exponential backoff
-- ✅ Health checking and auto-reconnection
-- ✅ Connection pooling and lifecycle management
-- ✅ TLS 1.2/1.3 enforcement
-- ✅ Tenant header support
-- ✅ Extension methods for common HTTP operations
+```bash
+# Define the version
+export VERSION=1.3.7 # or 1.3.7-beta for pre-release
 
-### Temporal Client Service
-- ✅ Lazy connection initialization
-- ✅ Automatic retry on connection failures
-- ✅ mTLS support
-- ✅ Health monitoring
-- ✅ Connection state management
-- ✅ Graceful disconnection
-- ✅ Sub-workflow (child workflow) support
-- ✅ Workflow orchestration and composition
+# Create and push a version tag
+git tag -a v$VERSION -m "Release v$VERSION"
+git push origin v$VERSION
+```
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Implement in-memory tracking for knowledge items in KnowledgeCollection
- Optimize DisplayKnowledgeSummaryAsync to use local cache instead of API calls
- Add release instructions to README with version tagging workflow

## Changes

### KnowledgeCollection Enhancements
- Added `_localKnowledge` list to track knowledge items in-memory
- Updated `UpdateAsync` to maintain local knowledge state after successful updates
- Updated `DeleteAsync` to remove items from local tracking after successful deletion
- Refactored `DisplayKnowledgeSummaryAsync` to use locally tracked knowledge for better performance

### README Updates
- Replaced detailed feature list with concise release instructions
- Added version tagging commands for releases

## Test plan
- [ ] Verify knowledge tracking works correctly during create/update operations
- [ ] Verify knowledge is removed from local tracking on successful delete
- [ ] Test DisplayKnowledgeSummaryAsync displays correct locally tracked items
- [ ] Ensure no breaking changes to existing functionality