### PR TITLE
feat: allow consumers to inject additional ILoggerProviders into Semantic Kernel

### DIFF
--- a/XiansAi.Lib.Src/Flow/SemanticRouter/SemanticRouterImpl.cs
+++ b/XiansAi.Lib.Src/Flow/SemanticRouter/SemanticRouterImpl.cs
@@ -265,10 +265,14 @@ internal class SemanticRouterHubImpl : IDisposable
         var builder = ConfigureKernelBuilder(options);
 
         // Configure logging
-        builder.Services.AddLogging(configure => 
+        builder.Services.AddLogging(configure =>
         {
             configure.AddConsole();
             configure.SetMinimumLevel(LogLevel.Information);
+
+            // Add any additional logger providers registered by consumers
+            foreach (var provider in Globals.AdditionalLoggerProviders)
+                configure.AddProvider(provider);
         });
 
         // To avoid infinite loops, we need to add the termination filter as a scoped service.

--- a/XiansAi.Lib.Src/Globals.cs
+++ b/XiansAi.Lib.Src/Globals.cs
@@ -37,4 +37,6 @@ public static class Globals
                    .AddFilter("System", consoleLogLevel)
                    .AddFilter((category, level) => level >= consoleLogLevel);
         });
+
+    public static ILoggerProvider[] AdditionalLoggerProviders = Array.Empty<ILoggerProvider>();
 }


### PR DESCRIPTION
## Summary

- Adds `Globals.AdditionalLoggerProviders` static field that consumers can populate with custom `ILoggerProvider` instances
- `BuildKernelAsync` now iterates over these providers and registers them with the Semantic Kernel's logging pipeline

This allows library consumers to hook into the Kernel's logging (e.g. to capture token usage metrics for PostHog, OpenTelemetry, or other telemetry systems) without modifying the library source.

## Usage

```csharp
// In consumer's Program.cs or startup
Globals.AdditionalLoggerProviders = new ILoggerProvider[]
{
    new MyCustomTelemetryLoggerProvider()
};
```

## Changes

- `Globals.cs` — new `AdditionalLoggerProviders` field (defaults to empty array)
- `SemanticRouterImpl.cs` — loop over additional providers inside `BuildKernelAsync`

## Test plan

- [x] Verified `dotnet build` and `dotnet pack` succeed
- [ ] Tested in consumer project (pengefix-ai) — custom provider receives Semantic Kernel log events including token usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)