### PR TITLE
bugfix: Restore IKnowledgeProvider interface and implementations by adding optional description and visibility parameters #63

### DIFF
--- a/Xians.Lib/Agents/Knowledge/KnowledgeService.cs
+++ b/Xians.Lib/Agents/Knowledge/KnowledgeService.cs
@@ -76,6 +76,8 @@ internal class KnowledgeService
             tenantId,
             systemScoped,
             activationName,
+            description,
+            visible,
             cancellationToken);
     }
 

--- a/Xians.Lib/Agents/Knowledge/Providers/IKnowledgeProvider.cs
+++ b/Xians.Lib/Agents/Knowledge/Providers/IKnowledgeProvider.cs
@@ -36,6 +36,8 @@ internal interface IKnowledgeProvider
         string? tenantId,
         bool systemScoped = false,
         string? activationName = null,
+        string? description = null,
+        bool visible = true,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/Xians.Lib/Agents/Knowledge/Providers/LocalKnowledgeProvider.cs
+++ b/Xians.Lib/Agents/Knowledge/Providers/LocalKnowledgeProvider.cs
@@ -106,6 +106,8 @@ internal class LocalKnowledgeProvider : IKnowledgeProvider
         string? tenantId,
         bool systemScoped = false,
         string? activationName = null,
+        string? description = null,
+        bool visible = true,
         CancellationToken cancellationToken = default)
     {
         _logger.LogDebug(
@@ -118,7 +120,9 @@ internal class LocalKnowledgeProvider : IKnowledgeProvider
             Content = content,
             Type = type ?? "text",
             Agent = agentName,
-            SystemScoped = systemScoped
+            SystemScoped = systemScoped,
+            Description = description,
+            Visible = visible
         };
 
         var storeKey = GetStoreKey(tenantId, agentName, activationName, knowledgeName);

--- a/Xians.Lib/Agents/Knowledge/Providers/ServerKnowledgeProvider.cs
+++ b/Xians.Lib/Agents/Knowledge/Providers/ServerKnowledgeProvider.cs
@@ -206,6 +206,8 @@ internal class ServerKnowledgeProvider : IKnowledgeProvider
         string? tenantId,
         bool systemScoped = false,
         string? activationName = null,
+        string? description = null,
+        bool visible = true,
         CancellationToken cancellationToken = default)
     {
         // Validate inputs
@@ -224,7 +226,9 @@ internal class ServerKnowledgeProvider : IKnowledgeProvider
             Content = content,
             Type = type,
             Agent = agentName,
-            SystemScoped = systemScoped
+            SystemScoped = systemScoped,
+            Description = description,
+            Visible = visible
         };
 
         _logger.LogDebug(


### PR DESCRIPTION
- Updated method signatures in KnowledgeService, LocalKnowledgeProvider, and ServerKnowledgeProvider to include `description` and `visible` parameters.
- Ensured default values for new parameters to maintain backward compatibility.