### PR TITLE
Refactor MessagingHelper and UserMessaging methods for supervisor con…

### DIFF
--- a/Xians.Lib/Agents/Core/MessagingHelper.cs
+++ b/Xians.Lib/Agents/Core/MessagingHelper.cs
@@ -152,7 +152,7 @@ public class MessagingHelper
     /// <param name="participantId">Optional participant (user) ID to send the message to. If null, uses the current workflow context.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <exception cref="InvalidOperationException">Thrown when not in workflow or activity context.</exception>
-    public async Task SendReasoningAsync(
+    public async Task SendReasoningMessageAsSupervisorAsync(
         string text,
         object? data = null,
         string? scope = null,
@@ -161,7 +161,7 @@ public class MessagingHelper
         string? participantId = null)
     {
         participantId ??= XiansContext.GetParticipantId();
-        await UserMessaging.SendReasoningAsync(participantId, text, data, scope, hint, taskId);
+        await UserMessaging.SendReasoningAsync(WorkflowConstants.WorkflowTypes.Supervisor, participantId, text, data, scope, hint, taskId);
     }
 
     /// <summary>
@@ -177,7 +177,7 @@ public class MessagingHelper
     /// <param name="participantId">Optional participant (user) ID to send the message to. If null, uses the current workflow context.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <exception cref="InvalidOperationException">Thrown when not in workflow or activity context.</exception>
-    public async Task SendToolAsync(
+    public async Task SendToolCallMessageAsSupervisorAsync(
         string text,
         object? data = null,
         string? scope = null,
@@ -186,7 +186,7 @@ public class MessagingHelper
         string? participantId = null)
     {
         participantId ??= XiansContext.GetParticipantId();
-        await UserMessaging.SendToolAsync(participantId, text, data, scope, hint, taskId);
+        await UserMessaging.SendToolCallAsync(WorkflowConstants.WorkflowTypes.Supervisor, participantId, text, data, scope, hint, taskId);
     }
 
     /// <summary>

--- a/Xians.Lib/Agents/Messaging/UserMessaging.cs
+++ b/Xians.Lib/Agents/Messaging/UserMessaging.cs
@@ -64,6 +64,7 @@ internal static class UserMessaging
     /// <returns>A task representing the async operation.</returns>
     /// <exception cref="InvalidOperationException">Thrown when not in a workflow or activity context.</exception>
     public static async Task SendReasoningAsync(
+        string builtInworkflowName,
         string participantId,
         string text,
         object? data = null,
@@ -71,7 +72,7 @@ internal static class UserMessaging
         string? hint = null,
         string? taskId = null)
     {
-        await SendMessageAsync(participantId, text, data, scope, hint, taskId, "reasoning");
+        await SendMessageAsWorkflowAsync(builtInworkflowName, participantId, text, data, scope, hint, taskId, "reasoning");
     }
 
     /// <summary>
@@ -86,7 +87,8 @@ internal static class UserMessaging
     /// <param name="taskId">Optional task ID to associate with the message.</param>
     /// <returns>A task representing the async operation.</returns>
     /// <exception cref="InvalidOperationException">Thrown when not in a workflow or activity context.</exception>
-    public static async Task SendToolAsync(
+    public static async Task SendToolCallAsync(
+        string builtInworkflowName,
         string participantId,
         string text,
         object? data = null,
@@ -94,7 +96,7 @@ internal static class UserMessaging
         string? hint = null,
         string? taskId = null)
     {
-        await SendMessageAsync(participantId, text, data, scope, hint, taskId, "tool");
+        await SendMessageAsWorkflowAsync(builtInworkflowName, participantId, text, data, scope, hint, taskId, "tool");
     }
 
     /// <summary>


### PR DESCRIPTION
…text

- Renamed SendReasoningAsync to SendReasoningMessageAsSupervisorAsync and SendToolAsync to SendToolCallMessageAsSupervisorAsync in MessagingHelper to clarify their purpose.
- Updated method signatures in UserMessaging to include a built-in workflow name parameter, enhancing the context for message sending.
- Adjusted internal method calls to align with the new supervisor workflow context, improving message handling consistency. #75