### PR TITLE
feat: Add parameters to pass the headers from web hook

### DIFF
--- a/Xians.Lib/Temporal/Workflows/Messaging/MessageProcessor.cs
+++ b/Xians.Lib/Temporal/Workflows/Messaging/MessageProcessor.cs
@@ -261,7 +261,8 @@ internal static class MessageProcessor
             WorkflowType = workflowType,
             Authorization = message.Payload.Authorization,
             ThreadId = message.Payload.ThreadId,
-            MessageType = messageType
+            MessageType = messageType,
+            Metadata = message.Payload.Metadata
         };
 
         await Workflow.ExecuteActivityAsync(

--- a/Xians.Lib/Temporal/Workflows/Messaging/Models/InboundMessage.cs
+++ b/Xians.Lib/Temporal/Workflows/Messaging/Models/InboundMessage.cs
@@ -25,20 +25,25 @@ public class InboundMessagePayload
     public required string ParticipantId { get; set; }
     public string? Authorization { get; set; }
     public required string Text { get; set; }
-    
+
     private string? _requestId;
-    public required string RequestId 
-    { 
-        
-        get => string.IsNullOrEmpty(_requestId) ? $"generated-{ (Workflow.InWorkflow ? Workflow.NewGuid().ToString() : Guid.NewGuid().ToString())}" : _requestId;
+    public required string RequestId
+    {
+
+        get => string.IsNullOrEmpty(_requestId) ? $"generated-{(Workflow.InWorkflow ? Workflow.NewGuid().ToString() : Guid.NewGuid().ToString())}" : _requestId;
         set => _requestId = value;
     }
-    
+
     public required string Hint { get; set; }
     public required string Scope { get; set; }
     public required object Data { get; set; }
     public required string Type { get; set; }
     public List<DbMessage>? History { get; set; }
+
+    /// <summary>
+    /// Optional metadata (e.g. Inbound HTTP headers form webhooks).
+    /// </summary>
+    public Dictionary<string, string>? Metadata { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
- `InboundMessagePayload.Metadata` — Adds optional Dictionary<string, string>? on the inbound signal payload
- `MessageProcessor` — Forwards message.Payload.Metadata into ProcessMessageActivityRequest so metadata pass through the workflow