### PR TITLE
passing activation name as post param instead of get when updating knowledge

### DIFF
--- a/Xians.Lib/Agents/Knowledge/Models/Knowledge.cs
+++ b/Xians.Lib/Agents/Knowledge/Models/Knowledge.cs
@@ -62,5 +62,11 @@ public class Knowledge
     /// Gets or sets whether this knowledge item is visible. Defaults to true.
     /// </summary>
     public bool Visible { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the optional activation name this knowledge is scoped to.
+    /// Sent in the request body on create; the server reads it from the body.
+    /// </summary>
+    public string? ActivationName { get; set; }
 }
 

--- a/Xians.Lib/Agents/Knowledge/Providers/ServerKnowledgeProvider.cs
+++ b/Xians.Lib/Agents/Knowledge/Providers/ServerKnowledgeProvider.cs
@@ -228,7 +228,8 @@ internal class ServerKnowledgeProvider : IKnowledgeProvider
             Agent = agentName,
             SystemScoped = systemScoped,
             Description = description,
-            Visible = visible
+            Visible = visible,
+            ActivationName = activationName
         };
 
         _logger.LogDebug(
@@ -242,11 +243,6 @@ internal class ServerKnowledgeProvider : IKnowledgeProvider
 
         // POST to api/agent/knowledge
         var endpoint = WorkflowConstants.ApiEndpoints.Knowledge;
-
-        if (!string.IsNullOrEmpty(activationName))
-        {
-            endpoint += $"?activationName={UrlEncoder.Default.Encode(activationName)}";
-        }
 
         using var httpRequest = new HttpRequestMessage(HttpMethod.Post, endpoint);
         httpRequest.Content = JsonContent.Create(knowledge);


### PR DESCRIPTION
Fix: send activationName in POST body instead of query string when updating knowledge

The knowledge create/update POST appended activationName as a query parameter, but the server's POST /api/agent/knowledge endpoint binds only [FromBody] KnowledgeCreateRequest and reads ActivationName from the body — so the value was silently dropped and created knowledge was never scoped to its activation.

Added ActivationName to the Knowledge model so it serializes into the POST body.
Removed the now-redundant query-string append from UpdateAsync.