### PR TITLE
fix: add explicit permissions to nuget-publish workflow

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -14,6 +14,8 @@ env:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` to the `build-and-publish` job in `.github/workflows/nuget-publish.yml`
- Restricts the `GITHUB_TOKEN` to the minimum required scope (the job only needs to checkout code and push to NuGet via an API key)
- Resolves CodeQL code-scanning alert [#1](https://github.com/XiansAiPlatform/XiansAi.Lib/security/code-scanning/1) — `actions/missing-workflow-permissions`

## Test plan

- [ ] Verify the workflow still triggers correctly on version tags (`v*`) and `workflow_dispatch`
- [ ] Confirm the CodeQL alert is dismissed after merge

Made with [Cursor](https://cursor.com)