### PR TITLE
feat: enhance file upload handling to support multiple files

### DIFF
--- a/Xians.Examples/FileUpload/Program.cs
+++ b/Xians.Examples/FileUpload/Program.cs
@@ -1,7 +1,6 @@
 using Xians.Lib.Agents.Core;
 using DotNetEnv;
 using Microsoft.Extensions.Logging;
-using System.Text.Json;
 
 Env.Load();
 
@@ -33,45 +32,38 @@ conversationalWorkflow.OnUserChatMessage(async (context) =>
 
 conversationalWorkflow.OnFileUpload(async (context) =>
 {
-    string base64Content;
-    string? fileName = null;
-    string? contentType = null;
+    var files = context.Message.Files;
 
-    if (context.Message.Data is JsonElement jsonElement)
-    {
-        base64Content = jsonElement.TryGetProperty("content", out var contentProp)
-            ? contentProp.GetString() ?? ""
-            : jsonElement.GetString() ?? "";
-        if (jsonElement.TryGetProperty("fileName", out var fn))
-            fileName = fn.GetString();
-        if (jsonElement.TryGetProperty("contentType", out var ct))
-            contentType = ct.GetString();
-    }
-    else
-    {
-        base64Content = context.Message.Data?.ToString() ?? "";
-        fileName = context.Message.Text;
-    }
-
-    if (string.IsNullOrEmpty(base64Content))
+    if (files.Count == 0)
     {
         await context.ReplyAsync("No file data received.");
         return;
     }
 
-    try
+    var saveDirectory = Path.Combine(Path.GetTempPath(), "xians-file-uploads");
+    Directory.CreateDirectory(saveDirectory);
+
+    var summaries = new List<string>();
+    foreach (var file in files)
     {
-        var fileBytes = Convert.FromBase64String(base64Content);
-        var displayName = fileName ?? "uploaded-file";
-        await context.ReplyAsync(
-            $"File received successfully! Processed {fileBytes.Length} bytes. " +
-            $"{(contentType != null ? $"Type: {contentType}. " : "")}" +
-            $"Name: {displayName}");
+        if (!file.TryGetBytes(out var fileBytes))
+        {
+            await context.ReplyAsync(
+                $"Invalid file format for '{file.FileName ?? "uploaded-file"}'. Please ensure the file is base64 encoded.");
+            return;
+        }
+
+        var fileName = Path.GetFileName(file.FileName ?? $"uploaded-file-{Guid.NewGuid():N}");
+        var savePath = Path.Combine(saveDirectory, fileName);
+        await File.WriteAllBytesAsync(savePath, fileBytes!);
+
+        summaries.Add(
+            $"{fileName} ({fileBytes!.Length} bytes" +
+            $"{(file.ContentType != null ? $", {file.ContentType}" : "")}) saved to {savePath}");
     }
-    catch (FormatException)
-    {
-        await context.ReplyAsync("Invalid file format. Please ensure the file is base64 encoded.");
-    }
+
+    await context.ReplyAsync(
+        $"Received {files.Count} file(s) with message '{context.Message.Text}' successfully! {string.Join(", ", summaries)}");
 });
 
 await xiansAgent.RunAllAsync();

--- a/Xians.Lib.Tests/UnitTests/Agents/FileUploadParserTests.cs
+++ b/Xians.Lib.Tests/UnitTests/Agents/FileUploadParserTests.cs
@@ -1,0 +1,303 @@
+using System.Text.Json;
+using Xunit;
+using Xians.Lib.Agents.Messaging;
+
+namespace Xians.Lib.Tests.UnitTests.Agents;
+
+public class FileUploadParserTests
+{
+    private static readonly string SampleBase64 = Convert.ToBase64String(new byte[] { 1, 2, 3, 4, 5 });
+
+    private static JsonElement ToJsonElement(string json) =>
+        JsonSerializer.Deserialize<JsonElement>(json);
+
+    [Fact]
+    public void Parse_MultiFileFormat_ReturnsAllFilesWithMetadata()
+    {
+        var json = $$"""
+        {
+            "files": [
+                { "content": "{{SampleBase64}}", "fileName": "report.pdf", "contentType": "application/pdf", "fileSize": 1024 },
+                { "content": "{{SampleBase64}}", "fileName": "photo.png", "contentType": "image/png" }
+            ]
+        }
+        """;
+
+        var files = FileUploadParser.Parse(ToJsonElement(json));
+
+        Assert.Equal(2, files.Count);
+
+        Assert.Equal(SampleBase64, files[0].Content);
+        Assert.Equal("report.pdf", files[0].FileName);
+        Assert.Equal("application/pdf", files[0].ContentType);
+        Assert.Equal(1024, files[0].FileSize);
+
+        Assert.Equal("photo.png", files[1].FileName);
+        Assert.Equal("image/png", files[1].ContentType);
+        Assert.Null(files[1].FileSize);
+    }
+
+    [Fact]
+    public void Parse_SingleFileObjectFormat_ReturnsOneFile()
+    {
+        var json = $$"""
+        { "content": "{{SampleBase64}}", "fileName": "invoice.pdf", "contentType": "application/pdf" }
+        """;
+
+        var files = FileUploadParser.Parse(ToJsonElement(json));
+
+        var file = Assert.Single(files);
+        Assert.Equal(SampleBase64, file.Content);
+        Assert.Equal("invoice.pdf", file.FileName);
+        Assert.Equal("application/pdf", file.ContentType);
+    }
+
+    [Fact]
+    public void Parse_RawBase64JsonString_UsesFallbackFileName()
+    {
+        var element = ToJsonElement($"\"{SampleBase64}\"");
+
+        var files = FileUploadParser.Parse(element, fallbackFileName: "from-text.pdf");
+
+        var file = Assert.Single(files);
+        Assert.Equal(SampleBase64, file.Content);
+        Assert.Equal("from-text.pdf", file.FileName);
+    }
+
+    [Fact]
+    public void Parse_PlainString_ReturnsOneFile()
+    {
+        var files = FileUploadParser.Parse(SampleBase64, fallbackFileName: "caption.txt");
+
+        var file = Assert.Single(files);
+        Assert.Equal(SampleBase64, file.Content);
+        Assert.Equal("caption.txt", file.FileName);
+    }
+
+    [Fact]
+    public void Parse_TopLevelArray_ReturnsAllFiles()
+    {
+        var json = $$"""
+        [
+            { "content": "{{SampleBase64}}", "fileName": "a.txt" },
+            { "content": "{{SampleBase64}}", "fileName": "b.txt" }
+        ]
+        """;
+
+        var files = FileUploadParser.Parse(ToJsonElement(json));
+
+        Assert.Equal(2, files.Count);
+        Assert.Equal("a.txt", files[0].FileName);
+        Assert.Equal("b.txt", files[1].FileName);
+    }
+
+    [Fact]
+    public void Parse_CaseInsensitivePropertyNames_ReturnsMetadata()
+    {
+        var json = $$"""
+        { "files": [{ "Content": "{{SampleBase64}}", "filename": "doc.pdf", "CONTENTTYPE": "application/pdf", "FileSize": 42 }] }
+        """;
+
+        var files = FileUploadParser.Parse(ToJsonElement(json));
+
+        var file = Assert.Single(files);
+        Assert.Equal(SampleBase64, file.Content);
+        Assert.Equal("doc.pdf", file.FileName);
+        Assert.Equal("application/pdf", file.ContentType);
+        Assert.Equal(42, file.FileSize);
+    }
+
+    [Fact]
+    public void Parse_FileSizeAsString_IsParsed()
+    {
+        var json = $$"""
+        { "content": "{{SampleBase64}}", "fileSize": "2048" }
+        """;
+
+        var files = FileUploadParser.Parse(ToJsonElement(json));
+
+        Assert.Equal(2048, Assert.Single(files).FileSize);
+    }
+
+    [Fact]
+    public void Parse_NullData_ReturnsEmpty()
+    {
+        Assert.Empty(FileUploadParser.Parse(null));
+    }
+
+    [Fact]
+    public void Parse_ObjectWithoutContent_ReturnsEmpty()
+    {
+        var files = FileUploadParser.Parse(ToJsonElement("""{ "fileName": "no-content.pdf" }"""));
+
+        Assert.Empty(files);
+    }
+
+    [Fact]
+    public void Parse_EntriesWithoutContent_AreSkipped()
+    {
+        var json = $$"""
+        { "files": [{ "fileName": "missing.pdf" }, { "content": "{{SampleBase64}}", "fileName": "ok.pdf" }] }
+        """;
+
+        var files = FileUploadParser.Parse(ToJsonElement(json));
+
+        Assert.Equal("ok.pdf", Assert.Single(files).FileName);
+    }
+
+    [Fact]
+    public void Parse_AnonymousObject_IsNormalizedThroughJson()
+    {
+        var data = new
+        {
+            files = new[]
+            {
+                new { content = SampleBase64, fileName = "typed.pdf", contentType = "application/pdf", fileSize = 99 }
+            }
+        };
+
+        var files = FileUploadParser.Parse(data);
+
+        var file = Assert.Single(files);
+        Assert.Equal("typed.pdf", file.FileName);
+        Assert.Equal(99, file.FileSize);
+    }
+
+    [Fact]
+    public void UploadedFile_GetBytes_DecodesBase64()
+    {
+        var file = new UploadedFile(SampleBase64);
+
+        Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, file.GetBytes());
+    }
+
+    [Fact]
+    public void UploadedFile_TryGetBytes_InvalidBase64_ReturnsFalse()
+    {
+        var file = new UploadedFile("not-valid-base64!!!");
+
+        Assert.False(file.TryGetBytes(out var bytes));
+        Assert.Null(bytes);
+    }
+
+    [Fact]
+    public void CurrentMessage_Files_DecodesMultiFilePayload()
+    {
+        var json = $$"""
+        { "files": [{ "content": "{{SampleBase64}}", "fileName": "report.pdf" }] }
+        """;
+
+        var message = new CurrentMessage(
+            text: "here are the files",
+            participantId: "user@example.com",
+            requestId: "req-1",
+            scope: null,
+            hint: null,
+            data: ToJsonElement(json),
+            tenantId: "default");
+
+        var file = Assert.Single(message.Files);
+        Assert.Equal("report.pdf", file.FileName);
+        Assert.Same(message.Files, message.Files); // cached
+    }
+
+    [Fact]
+    public void Parse_ReferenceFile_WithFileIdAndNoContent_ReturnsReference()
+    {
+        var json = """
+        { "files": [{ "fileId": "abc123", "fileName": "report.pdf", "contentType": "application/pdf", "fileSize": 1024 }] }
+        """;
+
+        var file = Assert.Single(FileUploadParser.Parse(ToJsonElement(json)));
+
+        Assert.Equal("abc123", file.FileId);
+        Assert.Equal("report.pdf", file.FileName);
+        Assert.Equal("application/pdf", file.ContentType);
+        Assert.Equal(1024, file.FileSize);
+        Assert.True(file.IsReference);
+        Assert.Equal(string.Empty, file.Content);
+    }
+
+    [Fact]
+    public void Parse_ReferenceFiles_MultipleReferences_ReturnsAll()
+    {
+        var json = """
+        { "files": [
+            { "fileId": "id-1", "fileName": "a.pdf" },
+            { "fileId": "id-2", "fileName": "b.pdf" }
+        ] }
+        """;
+
+        var files = FileUploadParser.Parse(ToJsonElement(json));
+
+        Assert.Equal(2, files.Count);
+        Assert.Equal("id-1", files[0].FileId);
+        Assert.Equal("id-2", files[1].FileId);
+        Assert.All(files, f => Assert.True(f.IsReference));
+    }
+
+    [Fact]
+    public void Parse_MixedInlineAndReferenceFiles_ReturnsBoth()
+    {
+        var json = $$"""
+        { "files": [
+            { "content": "{{SampleBase64}}", "fileName": "inline.pdf" },
+            { "fileId": "ref-1", "fileName": "reference.pdf" }
+        ] }
+        """;
+
+        var files = FileUploadParser.Parse(ToJsonElement(json));
+
+        Assert.Equal(2, files.Count);
+        Assert.False(files[0].IsReference);
+        Assert.Equal(SampleBase64, files[0].Content);
+        Assert.True(files[1].IsReference);
+        Assert.Equal("ref-1", files[1].FileId);
+    }
+
+    [Fact]
+    public void Parse_ObjectWithoutContentOrFileId_ReturnsEmpty()
+    {
+        var files = FileUploadParser.Parse(ToJsonElement("""{ "fileName": "no-ref.pdf" }"""));
+
+        Assert.Empty(files);
+    }
+
+    [Fact]
+    public void UploadedFile_ReferenceFile_ResolvingContent_ClearsIsReference()
+    {
+        var file = new UploadedFile(content: null, fileName: "r.pdf", contentType: null, fileSize: null, fileId: "id-9");
+
+        Assert.True(file.IsReference);
+        Assert.Equal(string.Empty, file.Content);
+
+        file.Content = SampleBase64;
+
+        Assert.False(file.IsReference);
+        Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, file.GetBytes());
+    }
+
+    [Fact]
+    public void UploadedFile_WithNeitherContentNorFileId_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new UploadedFile(content: null, fileName: "x", contentType: null, fileSize: null, fileId: null));
+    }
+
+    [Fact]
+    public void CurrentMessage_Files_RawBase64String_UsesTextAsFileName()
+    {
+        var message = new CurrentMessage(
+            text: "upload.bin",
+            participantId: "user@example.com",
+            requestId: "req-2",
+            scope: null,
+            hint: null,
+            data: SampleBase64,
+            tenantId: "default");
+
+        var file = Assert.Single(message.Files);
+        Assert.Equal("upload.bin", file.FileName);
+        Assert.Equal(SampleBase64, file.Content);
+    }
+}

--- a/Xians.Lib/Agents/Core/XiansWorkflow.cs
+++ b/Xians.Lib/Agents/Core/XiansWorkflow.cs
@@ -225,9 +225,13 @@ public class XiansWorkflow
 
     /// <summary>
     /// Registers a handler for file upload messages.
-    /// Triggered when a File message is received (type="File") with Data containing the base64 encoded file.
+    /// Triggered when a File message is received (type="File") with Data containing the base64 encoded file(s).
+    /// Access the uploaded files as typed objects via <c>context.Message.Files</c>, which decodes
+    /// the multi-file format <c>{ files: [{ content, fileName, contentType, fileSize }, ...] }</c>,
+    /// the single-file object format, and raw base64 string payloads.
+    /// The raw payload remains available via <c>context.Message.Data</c>.
     /// </summary>
-    /// <param name="handler">The async handler to process file uploads. Access the file via context.Message.Data (base64 string).</param>
+    /// <param name="handler">The async handler to process file uploads. Access the files via context.Message.Files.</param>
     public void OnFileUpload(Func<UserMessageContext, Task> handler)
     {
         if (!_isBuiltIn)

--- a/Xians.Lib/Agents/Messaging/CurrentMessage.cs
+++ b/Xians.Lib/Agents/Messaging/CurrentMessage.cs
@@ -6,6 +6,8 @@ namespace Xians.Lib.Agents.Messaging;
 /// </summary>
 public class CurrentMessage
 {
+    private IReadOnlyList<UploadedFile>? _files;
+
     /// <summary>Gets the text content of the message.</summary>
     public string Text { get; }
 
@@ -32,6 +34,17 @@ public class CurrentMessage
 
     /// <summary>The tenant ID for this message context.</summary>
     public string TenantId { get; }
+
+    /// <summary>
+    /// Gets the files decoded from the message data, typed as <see cref="UploadedFile"/> objects.
+    /// Primarily for File messages (type="File") handled by OnFileUpload handlers.
+    /// Supports the multi-file format <c>{ files: [{ content, fileName, contentType, fileSize }, ...] }</c>,
+    /// the single-file object format <c>{ content, fileName, contentType }</c>,
+    /// and a raw base64 string (in which case <see cref="Text"/> is used as the file name).
+    /// Returns an empty list when the data contains no recognizable file content.
+    /// </summary>
+    public IReadOnlyList<UploadedFile> Files =>
+        _files ??= FileUploadParser.Parse(Data, string.IsNullOrEmpty(Text) ? null : Text);
 
     internal CurrentMessage(
         string text,

--- a/Xians.Lib/Agents/Messaging/FileDownloadService.cs
+++ b/Xians.Lib/Agents/Messaging/FileDownloadService.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Logging;
+using Xians.Lib.Common;
+
+namespace Xians.Lib.Agents.Messaging;
+
+/// <summary>
+/// Downloads message file attachments stored out-of-band (GridFS) from the Xians platform.
+/// File messages carry only references (fileId + metadata); the bytes are fetched on demand
+/// so <see cref="UploadedFile.Content"/> / <see cref="UploadedFile.GetBytes"/> keep working.
+/// </summary>
+internal class FileDownloadService
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger _logger;
+
+    public FileDownloadService(HttpClient httpClient, ILogger logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Downloads the raw bytes of a stored file by its id, scoped to the given tenant.
+    /// </summary>
+    public async Task<byte[]> DownloadAsync(string fileId, string tenantId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(fileId))
+        {
+            throw new ArgumentException("fileId is required", nameof(fileId));
+        }
+
+        var endpoint = $"{WorkflowConstants.ApiEndpoints.Files}/{Uri.EscapeDataString(fileId)}";
+
+        _logger.LogDebug("Downloading file {FileId} from {Endpoint}", fileId, endpoint);
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Get, endpoint);
+        if (!string.IsNullOrEmpty(tenantId))
+        {
+            httpRequest.Headers.TryAddWithoutValidation(WorkflowConstants.Headers.TenantId, tenantId);
+        }
+
+        var response = await _httpClient.SendAsync(httpRequest, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogError(
+                "Failed to download file {FileId}: StatusCode={StatusCode}, Error={Error}",
+                fileId, response.StatusCode, error);
+            throw new HttpRequestException(
+                $"Failed to download file '{fileId}'. Status: {response.StatusCode}");
+        }
+
+        return await response.Content.ReadAsByteArrayAsync(cancellationToken);
+    }
+}

--- a/Xians.Lib/Agents/Messaging/FileUploadParser.cs
+++ b/Xians.Lib/Agents/Messaging/FileUploadParser.cs
@@ -1,0 +1,191 @@
+using System.Text.Json;
+
+namespace Xians.Lib.Agents.Messaging;
+
+/// <summary>
+/// Decodes file upload payloads from message data into typed <see cref="UploadedFile"/> objects.
+/// Supports all wire formats used by File messages (type="File"):
+/// <list type="bullet">
+/// <item>Multi-file: <c>{ "files": [{ "content", "fileName", "contentType", "fileSize" }, ...] }</c></item>
+/// <item>Single object: <c>{ "content", "fileName", "contentType", "fileSize" }</c></item>
+/// <item>Raw base64 string: <c>"JVBERi0x..."</c></item>
+/// </list>
+/// </summary>
+internal static class FileUploadParser
+{
+    /// <summary>
+    /// Parses message data into a list of uploaded files.
+    /// Returns an empty list when the data is null or contains no recognizable file content.
+    /// </summary>
+    /// <param name="data">The message data (JsonElement, string, or serializable object).</param>
+    /// <param name="fallbackFileName">Optional file name to use for raw base64 payloads (typically the message text).</param>
+    public static IReadOnlyList<UploadedFile> Parse(object? data, string? fallbackFileName = null)
+    {
+        if (data == null)
+        {
+            return Array.Empty<UploadedFile>();
+        }
+
+        var element = ToJsonElement(data);
+        if (element == null)
+        {
+            // Non-JSON data (e.g. a plain string): treat as raw base64 content
+            var raw = data.ToString();
+            return string.IsNullOrEmpty(raw)
+                ? Array.Empty<UploadedFile>()
+                : new[] { new UploadedFile(raw, fallbackFileName) };
+        }
+
+        return Parse(element.Value, fallbackFileName);
+    }
+
+    private static IReadOnlyList<UploadedFile> Parse(JsonElement element, string? fallbackFileName)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.String:
+                var content = element.GetString();
+                return string.IsNullOrEmpty(content)
+                    ? Array.Empty<UploadedFile>()
+                    : new[] { new UploadedFile(content, fallbackFileName) };
+
+            case JsonValueKind.Array:
+                return ParseFileArray(element);
+
+            case JsonValueKind.Object:
+                // Multi-file format: { files: [...] }
+                if (TryGetPropertyIgnoreCase(element, "files", out var filesProp) &&
+                    filesProp.ValueKind == JsonValueKind.Array)
+                {
+                    return ParseFileArray(filesProp);
+                }
+
+                // Single file object format: { content, fileName, ... }
+                var single = ParseFileObject(element);
+                return single != null ? new[] { single } : Array.Empty<UploadedFile>();
+
+            default:
+                return Array.Empty<UploadedFile>();
+        }
+    }
+
+    private static IReadOnlyList<UploadedFile> ParseFileArray(JsonElement array)
+    {
+        var files = new List<UploadedFile>();
+        foreach (var item in array.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.Object)
+            {
+                var file = ParseFileObject(item);
+                if (file != null)
+                {
+                    files.Add(file);
+                }
+            }
+            else if (item.ValueKind == JsonValueKind.String)
+            {
+                var content = item.GetString();
+                if (!string.IsNullOrEmpty(content))
+                {
+                    files.Add(new UploadedFile(content));
+                }
+            }
+        }
+        return files;
+    }
+
+    private static UploadedFile? ParseFileObject(JsonElement obj)
+    {
+        // Inline content (base64) is optional: reference-only files carry a "fileId" instead,
+        // and their bytes are resolved from server storage before the handler runs.
+        string? content = null;
+        if (TryGetPropertyIgnoreCase(obj, "content", out var contentProp) &&
+            contentProp.ValueKind == JsonValueKind.String)
+        {
+            content = contentProp.GetString();
+        }
+
+        string? fileId = null;
+        if (TryGetPropertyIgnoreCase(obj, "fileId", out var fid) && fid.ValueKind == JsonValueKind.String)
+        {
+            fileId = fid.GetString();
+        }
+
+        // A file object must provide either inline content or a storage reference.
+        if (string.IsNullOrEmpty(content) && string.IsNullOrEmpty(fileId))
+        {
+            return null;
+        }
+
+        string? fileName = null;
+        if (TryGetPropertyIgnoreCase(obj, "fileName", out var fn) && fn.ValueKind == JsonValueKind.String)
+        {
+            fileName = fn.GetString();
+        }
+
+        string? contentType = null;
+        if (TryGetPropertyIgnoreCase(obj, "contentType", out var ct) && ct.ValueKind == JsonValueKind.String)
+        {
+            contentType = ct.GetString();
+        }
+
+        long? fileSize = null;
+        if (TryGetPropertyIgnoreCase(obj, "fileSize", out var fs))
+        {
+            if (fs.ValueKind == JsonValueKind.Number && fs.TryGetInt64(out var size))
+            {
+                fileSize = size;
+            }
+            else if (fs.ValueKind == JsonValueKind.String && long.TryParse(fs.GetString(), out var sizeFromString))
+            {
+                fileSize = sizeFromString;
+            }
+        }
+
+        return new UploadedFile(content, fileName, contentType, fileSize, fileId);
+    }
+
+    private static bool TryGetPropertyIgnoreCase(JsonElement obj, string name, out JsonElement value)
+    {
+        if (obj.TryGetProperty(name, out value))
+        {
+            return true;
+        }
+
+        foreach (var property in obj.EnumerateObject())
+        {
+            if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static JsonElement? ToJsonElement(object data)
+    {
+        if (data is JsonElement element)
+        {
+            return element;
+        }
+
+        if (data is string)
+        {
+            return null;
+        }
+
+        // Data deserialized into another shape (e.g. dictionaries from the Temporal payload
+        // converter): normalize through JSON so all formats are handled uniformly.
+        try
+        {
+            return JsonSerializer.SerializeToElement(data);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+}

--- a/Xians.Lib/Agents/Messaging/UploadedFile.cs
+++ b/Xians.Lib/Agents/Messaging/UploadedFile.cs
@@ -1,0 +1,77 @@
+namespace Xians.Lib.Agents.Messaging;
+
+/// <summary>
+/// Represents a single file received via a File message (type="File").
+/// Provides typed access to the base64 content and optional metadata,
+/// removing the need for manual JSON parsing in OnFileUpload handlers.
+/// </summary>
+public class UploadedFile
+{
+    /// <summary>
+    /// The base64 encoded file content. Empty for reference-only files (those carrying a
+    /// <see cref="FileId"/>) until the bytes are resolved from server storage.
+    /// </summary>
+    public string Content { get; internal set; }
+
+    /// <summary>The file name, if provided by the client.</summary>
+    public string? FileName { get; }
+
+    /// <summary>The MIME content type (e.g. "application/pdf"), if provided by the client.</summary>
+    public string? ContentType { get; }
+
+    /// <summary>The file size in bytes, if provided by the client.</summary>
+    public long? FileSize { get; }
+
+    /// <summary>
+    /// The server storage id for files stored out-of-band (GridFS). When set, the content is
+    /// downloaded on demand and populated into <see cref="Content"/> before the handler runs.
+    /// </summary>
+    public string? FileId { get; }
+
+    /// <summary>True when this file carries only a reference and its bytes are not yet resolved.</summary>
+    public bool IsReference => !string.IsNullOrEmpty(FileId) && string.IsNullOrEmpty(Content);
+
+    public UploadedFile(string content, string? fileName = null, string? contentType = null, long? fileSize = null)
+        : this(content, fileName, contentType, fileSize, fileId: null)
+    {
+    }
+
+    public UploadedFile(string? content, string? fileName, string? contentType, long? fileSize, string? fileId)
+    {
+        // Content may be empty for reference-only files, but a file must have either content or a fileId.
+        if (string.IsNullOrEmpty(content) && string.IsNullOrEmpty(fileId))
+        {
+            throw new ArgumentException("An uploaded file must have either content or a fileId.", nameof(content));
+        }
+        Content = content ?? string.Empty;
+        FileName = fileName;
+        ContentType = contentType;
+        FileSize = fileSize;
+        FileId = fileId;
+    }
+
+    /// <summary>
+    /// Decodes the base64 content into raw bytes.
+    /// </summary>
+    /// <exception cref="FormatException">Thrown when the content is not valid base64.</exception>
+    public byte[] GetBytes() => Convert.FromBase64String(Content);
+
+    /// <summary>
+    /// Attempts to decode the base64 content into raw bytes without throwing.
+    /// </summary>
+    /// <param name="bytes">The decoded bytes, or null when the content is not valid base64.</param>
+    /// <returns>True when decoding succeeded.</returns>
+    public bool TryGetBytes(out byte[]? bytes)
+    {
+        try
+        {
+            bytes = Convert.FromBase64String(Content);
+            return true;
+        }
+        catch (FormatException)
+        {
+            bytes = null;
+            return false;
+        }
+    }
+}

--- a/Xians.Lib/Common/WorkflowConstants.cs
+++ b/Xians.Lib/Common/WorkflowConstants.cs
@@ -73,6 +73,8 @@ public static class WorkflowConstants
         public const string AgentDefinitions = "/api/agent/definitions";
         public const string FlowServerSettings = "/api/agent/settings/flowserver";
         public const string Documents = "api/agent/documents";
+        /// <summary>Base path for downloading message file attachments by id.</summary>
+        public const string Files = "api/agent/files";
         public const string Knowledge = "api/agent/knowledge";
         public const string KnowledgeLatest = "api/agent/knowledge/latest";
         public const string KnowledgeLatestSystem = "api/agent/knowledge/latest/system";

--- a/Xians.Lib/Temporal/Workflows/Messaging/MessageActivities.cs
+++ b/Xians.Lib/Temporal/Workflows/Messaging/MessageActivities.cs
@@ -16,6 +16,7 @@ public class MessageActivities
 {
     private readonly HttpClient _httpClient;
     private readonly Xians.Lib.Agents.Messaging.MessageService _messageService;
+    private readonly Xians.Lib.Agents.Messaging.FileDownloadService _fileDownloadService;
 
     public MessageActivities(HttpClient httpClient)
     {
@@ -24,6 +25,10 @@ public class MessageActivities
         // Create shared message service
         var logger = Xians.Lib.Common.Infrastructure.LoggerFactory.CreateLogger<Xians.Lib.Agents.Messaging.MessageService>();
         _messageService = new Xians.Lib.Agents.Messaging.MessageService(httpClient, logger);
+
+        // Downloads out-of-band (GridFS) file bytes referenced by File messages.
+        var fileLogger = Xians.Lib.Common.Infrastructure.LoggerFactory.CreateLogger<Xians.Lib.Agents.Messaging.FileDownloadService>();
+        _fileDownloadService = new Xians.Lib.Agents.Messaging.FileDownloadService(httpClient, fileLogger);
     }
 
     /// <summary>
@@ -100,6 +105,13 @@ public class MessageActivities
                 request.ThreadId,
                 request.Metadata
             );
+
+            // For File messages, resolve any reference-only files (bytes stored in GridFS)
+            // by downloading them so OnFileUpload handlers can read context.Message.Files transparently.
+            if (messageType == "file")
+            {
+                await ResolveReferenceFilesAsync(context, request.TenantId);
+            }
 
             // Invoke the registered handler (which makes agent API calls and sends responses)
             await handler(context);
@@ -366,6 +378,35 @@ public class MessageActivities
                 request.TargetWorkflowId,
                 request.TargetWorkflowType);
             throw;
+        }
+    }
+
+    /// <summary>
+    /// Downloads the bytes for any reference-only files (those carrying a fileId but no inline
+    /// content) and populates their <see cref="UploadedFile.Content"/> so handlers see resolved files.
+    /// </summary>
+    private async Task ResolveReferenceFilesAsync(ActivityUserMessageContext context, string tenantId)
+    {
+        var files = context.Message.Files;
+        if (files.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var file in files)
+        {
+            if (!file.IsReference || string.IsNullOrEmpty(file.FileId))
+            {
+                continue;
+            }
+
+            var bytes = await _fileDownloadService.DownloadAsync(file.FileId, tenantId);
+            file.Content = Convert.ToBase64String(bytes);
+
+            ActivityExecutionContext.Current.Logger.LogDebug(
+                "Resolved reference file {FileId} ({ByteCount} bytes)",
+                file.FileId,
+                bytes.Length);
         }
     }
 

--- a/Xians.Lib/docs/Examples/RecommendedUsageExample.cs
+++ b/Xians.Lib/docs/Examples/RecommendedUsageExample.cs
@@ -147,9 +147,6 @@ public class ServerSettingsExample
     public string FlowServerNamespace { get; set; } = "production";
     public string? FlowServerCertBase64 { get; set; }
     public string? FlowServerPrivateKeyBase64 { get; set; }
-    public string ApiKey { get; set; } = "...";
-    public string? ProviderName { get; set; } = "openai";
-    public string ModelName { get; set; } = "gpt-4";
 }
 
 


### PR DESCRIPTION
Updated the file upload workflow to handle multiple files, allowing users to upload several files in a single message. The implementation now checks for file data, saves uploaded files to a temporary directory, and provides detailed feedback on the upload status. Additionally, the documentation has been updated to reflect the new multi-file format support.