### PR TITLE
chore: mark SendHandoffAsync methods as deprecated

### DIFF
--- a/Xians.Lib/Agents/Messaging/MessageActivityExecutor.cs
+++ b/Xians.Lib/Agents/Messaging/MessageActivityExecutor.cs
@@ -69,6 +69,7 @@ internal class MessageActivityExecutor : ContextAwareActivityExecutor<MessageAct
     /// <summary>
     /// Sends a handoff request using context-aware execution.
     /// </summary>
+    [Obsolete("This method is deprecated and will be removed in a future version.")]
     public async Task<string?> SendHandoffAsync(SendHandoffRequest request)
     {
         return await ExecuteAsync(

--- a/Xians.Lib/Agents/Messaging/MessageService.cs
+++ b/Xians.Lib/Agents/Messaging/MessageService.cs
@@ -334,6 +334,7 @@ internal class MessageService
     /// <param name="request">The send handoff request containing target workflow information and message details.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The response from the handoff operation.</returns>
+    [Obsolete("This method is deprecated and will be removed in a future version.")]
     public async Task<string?> SendHandoffAsync(
         SendHandoffRequest request,
         CancellationToken cancellationToken = default)

--- a/Xians.Lib/Agents/Messaging/UserMessageContext.cs
+++ b/Xians.Lib/Agents/Messaging/UserMessageContext.cs
@@ -217,6 +217,7 @@ public class UserMessageContext
     /// <param name="data">Optional data to pass with the handoff. If null, uses the current message data.</param>
     /// <param name="userMessage">Optional message to send to the user before the handoff.</param>
     /// <returns>The response from the handoff operation.</returns>
+    [Obsolete("This method is deprecated and will be removed in a future version.")]
     public virtual async Task<string?> SendHandoffAsync(string targetWorkflowId, string? message = null, object? data = null, string? userMessage = null)
     {
         if (string.IsNullOrEmpty(targetWorkflowId))
@@ -276,6 +277,7 @@ public class UserMessageContext
     /// Internal method to send handoff requests.
     /// Context-aware: Uses activity in workflow, direct service call in activity.
     /// </summary>
+    [Obsolete("This method is deprecated and will be removed in a future version.")]
     private async Task<string?> SendHandoffInternalAsync(string targetWorkflowId, string? targetWorkflowType, string? message, object? data)
     {
         if (string.IsNullOrEmpty(Message.ThreadId))

--- a/Xians.Lib/Temporal/Workflows/Messaging/MessageActivities.cs
+++ b/Xians.Lib/Temporal/Workflows/Messaging/MessageActivities.cs
@@ -353,6 +353,7 @@ public class MessageActivities
     /// Delegates to shared MessageService.
     /// </summary>
     [Activity]
+    [Obsolete("This method is deprecated and will be removed in a future version.")]
     public async Task<string?> SendHandoffAsync(SendHandoffRequest request)
     {
         ActivityExecutionContext.Current.Logger.LogDebug(


### PR DESCRIPTION
Added [Obsolete] attribute to SendHandoffAsync methods across multiple classes, indicating that these methods are deprecated and will be removed in a future version. This change applies to MessageActivityExecutor, MessageService, UserMessageContext, and MessageActivities, ensuring clarity for future development and usage.